### PR TITLE
Sketch cell sampling from mutation tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,23 @@
+# Data files
+*.csv
+*.npy
+*.npz
+*.gzip
+*.tar
+*.tar.gz
+
+# Poetry lock
+poetry.lock
+
+# Notebooks are disallowed by default
+*.nb
+*.ipynb
+
+# Environmental files
+.idea/
+.DS_Store
+.ipynb_checkpoints/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,11 @@ repos:
     hooks:
       - id: interrogate
         args: [--quiet, --fail-under=95]
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.296
+  - repo: local
     hooks:
-    - id: pyright
+      - id: pyright
+        name: pyright
+        entry: poetry run pyright
+        language: node
+        pass_filenames: true
+        types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.9"
 numpy = "^1.24.2"
 jax = "^0.4.4"
 jaxlib = "^0.4.4"
+typing-extensions = "^4.5.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -41,6 +42,14 @@ verbose = 2
 quiet = false
 whitelist-regex = []
 color = true
+
+[tool.pyright]
+include = ["src"]
+exclude = ["**/node_modules",
+    "**/__pycache__",
+    "src/experimental",
+    "src/typestubs"
+]
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ packages = [{include = "pyggdrasil", from = "src"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 numpy = "^1.24.2"
+jax = "^0.4.4"
+jaxlib = "^0.4.4"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/pyggdrasil/interface/__init__.py
+++ b/src/pyggdrasil/interface/__init__.py
@@ -1,0 +1,8 @@
+"""Commonly used interfaces, used across different subpackages.
+
+Note:
+  - Subpackage-specific interfaces should be
+    in a subpackage's version of such module.
+  - This subpackage should not depend on other subpackages, so we
+    do not introduce circular imports.
+"""

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -1,0 +1,1 @@
+"""Mutation tree inference from scDNA matrices."""

--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -4,22 +4,28 @@ Note:
     This submodule should not import other submodules,
     so we do not introduce circular imports.
 """
-from typing import Any
+from typing import Union
+
+import jax
 from jax.random import PRNGKeyArray
 import numpy as np
 
 # JAX random key
 JAXRandomKey = PRNGKeyArray
 
+# Type annotation for a generic array.
+Array = Union[jax.Array, np.ndarray]
 
-# TODO(Pawel): This class for mutation trees
-# needs to be made precise later.
-# Probably, it'll be a subtype of a general labeled tree.
-MutationTreeMatrix = Any
+# A matrix of shape (n_nodes, n_nodes).
+# Represents the adjacency matrix of a tree, i.e. A[k, m] = 1
+# if node k is the parent of m.
+# Note that we do not include self-loops, so that the diagonal A[k, k] = 0.
+# Additionally, we will assume that 0 is the root.
+# In particular, A[:, 0] is the zero vector.
+TreeAdjacencyMatrix = Array
 
-# Mutation matrix type. It should be a numpy array of a specified format.
+# Represents mutations in sampled cells (n_cells, n_sites)
 MutationMatrix = np.ndarray
-
 # Apart from 0 (no mutation) and 1 (mutation present) we can observe these values
 # in the experimentally obtained matrices:
 HOMOZYGOUS_MUTATION: int = (

--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -1,0 +1,28 @@
+"""Subpackage-specific interfaces.
+
+Note:
+    This submodule should not import other submodules,
+    so we do not introduce circular imports.
+"""
+from typing import Any
+from jax.random import PRNGKeyArray
+import numpy as np
+
+# JAX random key
+JAXRandomKey = PRNGKeyArray
+
+
+# TODO(Pawel): This class for mutation trees
+# needs to be made precise later.
+# Probably, it'll be a subtype of a general labeled tree.
+MutationTreeMatrix = Any
+
+# Mutation matrix type. It should be a numpy array of a specified format.
+MutationMatrix = np.ndarray
+
+# Apart from 0 (no mutation) and 1 (mutation present) we can observe these values
+# in the experimentally obtained matrices:
+HOMOZYGOUS_MUTATION: int = (
+    2  # Homozygous mutation observed. See Eq. (8) on p. 5 of the SCITE paper.
+)
+MISSING_ENTRY: int = 3  # Missing entry.

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -72,7 +72,7 @@ class CellAttachmentStrategy(Enum):
 
 def attach_cells_to_tree(
     rng: interface.JAXRandomKey,
-    tree: interface.MutationTreeMatrix,
+    tree: interface.TreeAdjacencyMatrix,
     n_cells: int,
     strategy: CellAttachmentStrategy,
 ) -> PerfectMutationMatrix:
@@ -80,7 +80,7 @@ def attach_cells_to_tree(
 
     Args:
         rng: JAX random key
-        tree: mutation tree
+        tree: matrix representing mutation tree
         n_cells: number of cells to sample
         strategy: cell attachment strategy.
           See ``CellAttachmentStrategy`` for more information.

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -1,0 +1,95 @@
+"""Simulations of mutation matrices from mutation trees."""
+from enum import Enum
+
+import numpy as np
+from jax import random
+
+import pyggdrasil.tree_inference._interface as interface
+
+# Mutation matrix without noise
+PerfectMutationMatrix = np.ndarray
+
+
+def add_noise_to_perfect_matrix(
+    rng: interface.JAXRandomKey,
+    matrix: PerfectMutationMatrix,
+    false_positive_rate: float = 1e-5,
+    false_negative_rate: float = 1e-2,
+    missing_entry_rate: float = 1e-2,
+    observe_homozygous: bool = False,
+) -> interface.MutationMatrix:
+    """
+
+    Args:
+        rng: JAX random key
+        matrix: binary matrix with 1 at sites where a mutation is present.
+          Shape (n_cells, n_sites).
+        false_positive_rate: false positive rate :math:`\\alpha`.
+          Should be in the half-open interval [0, 1).
+        false_negative_rate: false negative rate :math:`\\beta`.
+          Should be in the half-open interval [0, 1).
+        missing_entry_rate: fraction os missing entries.
+          Should be in the half-open interval [0, 1).
+          If 0, no missing entries are present.
+        observe_homozygous: if true, some homozygous mutations will be observed
+          due to noise. See Eq. (8) on p. 5 of the original SCITE paper.
+
+    Returns:
+        array with shape (n_cells, n_sites)
+          with the observed mutations and ``int`` data type.
+          Entries will be:
+            - 0 (no mutation)
+            - 1 (mutation present)
+            - ``HOMOZYGOUS_MUTATION`` if ``observe_homozygous`` is true
+            - ``MISSING ENTRY`` if ``missing_entry_rate`` is non-zero
+    """
+    # RNGs for false positives, false negatives, and missing data
+    rng_false_pos, rng_false_neg, rng_miss = random.split(rng, 3)
+
+    # TODO(Pawel, Gordon): Now probably it's the easiest to draw from random.bernoulli
+    #   matrices corresponding to the false positives and false negatives
+    #   and adjust the mutation matrix accordingly
+
+    # Now the matrix can be adjusted according to missing entry simulation
+
+    raise NotImplementedError("This function needs to be implemented.")
+
+
+class CellAttachmentStrategy(Enum):
+    """Enum representing valid strategies for attaching
+    cells to the mutation tree.
+
+    Allowed values:
+      - UNIFORM_INCLUDE_ROOT: each node in the tree has equal probability
+          of being attached a cell
+      - UNIFORM_EXCLUDE_ROOT: each non-root node in the tree has equal probability
+          of being attached a cell
+    """
+
+    UNIFORM_INCLUDE_ROOT = "UNIFORM_INCLUDE_ROOT"
+    UNIFORM_EXCLUDE_ROOT = "UNIFORM_EXCLUDE_ROOT"
+
+
+def attach_cells_to_tree(
+    rng: interface.JAXRandomKey,
+    tree: interface.MutationTreeMatrix,
+    n_cells: int,
+    strategy: CellAttachmentStrategy,
+) -> PerfectMutationMatrix:
+    """Attaches cells to the mutation tree.
+
+    Args:
+        rng: JAX random key
+        tree: mutation tree
+        n_cells: number of cells to sample
+        strategy: cell attachment strategy.
+          See ``CellAttachmentStrategy`` for more information.
+
+    Returns:
+        binary matrix of shape ``(n_cells, n_sites)``,
+          where ``n_sites`` is determined from the ``tree``
+    """
+    if n_cells < 1:
+        raise ValueError(f"Number of sampled cells {n_cells} cannot be less than 1.")
+
+    raise NotImplementedError("This function needs to be implemented.")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,7 +1,9 @@
+"""Check if basic functionalities of the public API are available."""
 from types import ModuleType
 
 
-def test_install():
+def test_install() -> None:
+    """Global module import."""
     import pyggdrasil as ygg
 
     assert isinstance(ygg, ModuleType)

--- a/tests/tree_inference/test_simulate.py
+++ b/tests/tree_inference/test_simulate.py
@@ -1,0 +1,1 @@
+"""Tests of the cell data simulations."""


### PR DESCRIPTION
This PR sketches the API for sampling the mutation matrices from a mutation tree.

Most files modified can be safely ignored (as they are just environment settings and boilerplate). The files important to review and comment on are in the `tree_inference` subpackage.