### PR TITLE
Log Likelihood of a Tree

### DIFF
--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -48,4 +48,5 @@ CellAttachmentVector = Array
 # Additionally, we will assume that highest index node is the root.
 # In particular, A[:, -1] is a zero vector all but the last element,
 # i.e. [0,0,...0,0,1]
+# A node is it's own ancestor.
 AncestorMatrix = Array

--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -48,5 +48,5 @@ CellAttachmentVector = Array
 # Additionally, we will assume that highest index node is the root.
 # In particular, A[:, -1] is a zero vector all but the last element,
 # i.e. [0,0,...0,0,1]
-# A node is it's own ancestor.
+# A node is its own ancestor.
 AncestorMatrix = Array

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -1,0 +1,13 @@
+"""Implementation of the log-probability functions.
+
+The log-probability functions are used to calculate the log-probability of a tree.
+"""
+
+
+def logprobability_fn():
+    """Returns a function that calculates the log-probability of a tree.
+
+    Returns:
+        function that takes a tree and returns it's log-probability
+    """
+    raise NotImplementedError("Not implemented yet.")

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -28,21 +28,6 @@ def logprobability_fn(
     # TODO: consider using jsps.special.logsumexp
     # TODO: consider using jnp.einsum
 
-    # likelihood = None
-    #
-    # # P( \sigma_j | T, \theta)
-    # attch_prior = jnp.array([0.5, 0.5])  # TODO: implement this
-    # # prod_{i=1}^{n} P(D_{ij} | A(T)_{i˜sigma(j)})
-    # prod_cells_likelihood = jnp.prod(likelihood)
-    # # [prod_cells_likelihood] * attch_prior
-    # prod_cells_likelihood_attch_prior = prod_cells_likelihood * attch_prior
-    # # log sum_{\simga_j = 1}^{n+1}
-    # log_prob_cells = jsp.special.logsumexp(prod_cells_likelihood_attch_prior)
-    # # sum_{j=1}^{m}
-    # jnp.sum(log_prob_cells)
-
-    # result = jnp.einsum("ij,ij->i", likelihood, attch_prior)
-
     raise NotImplementedError("Not implemented yet.")
 
 
@@ -101,3 +86,25 @@ def _mutation_likelihood(
     mutation_likelihood = _compute_mutation_likelihood(mutation_status, ancestor)
 
     return mutation_likelihood
+
+
+def _attachment_prior(
+    sigma: int,
+    tree: Tree,
+    theta: tuple[float, float]
+    # TODO: perhaps add CellAttachmentStrategy here ?
+) -> float:
+    """Returns the attachment prior.
+
+    Args:
+        sigma: mutation node the cell is attached to
+        tree: tree object contains the tree topology, labels
+        theta: \theta = (\alpha, \beta) error rates
+
+    Returns:
+        attachment prior - P(\sigma_{j} |T, \theta)
+    """
+
+    # TODO: what is this even ? - uniform prior ? Just 1/ n (+1) ?
+
+    raise NotImplementedError("Not implemented yet.")

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -114,8 +114,6 @@ def _mutation_likelihood(
     n, m = mutation_matrix.shape
     alpha, beta = theta
 
-    # TODO: Triple-check if this is the correct @ Pawel @ Gordon
-
     # truncate ancestor matrix
     ancestor_matrix = ancestor_matrix[:-1]
 

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -6,7 +6,7 @@ The log-probability functions are used to calculate the log-probability of a tre
 import pyggdrasil.tree_inference._tree as tr
 from pyggdrasil.tree_inference._tree import Tree
 
-from pyggdrasil.tree_inference._interface import MutationMatrix, CellAttachmentVector
+from pyggdrasil.tree_inference._interface import MutationMatrix
 
 
 def logprobability_fn(
@@ -46,10 +46,10 @@ def logprobability_fn(
     raise NotImplementedError("Not implemented yet.")
 
 
-def single_likelihood(
+def _mutation_likelihood(
     cell: int,
     mutation: int,
-    sigma: CellAttachmentVector,
+    sigma: int,
     tree: Tree,
     mutation_mat: MutationMatrix,
 ):
@@ -59,23 +59,45 @@ def single_likelihood(
         cell: cell index
         mutation: mutation index
         sigma: mutation node the cell is attached to
-        tree: tree
+        tree: tree object contains the tree topology, labels
 
     Returns:
-        likelihood of the cell / mutation
-        prod_{i=1}^{n} P(D_{ij} | A(T)_{i˜sigma_j})
+        likelihood of the cell / mutation - see Equation 13
+        P(D_{ij} | A(T)_{i˜sigma_j})
 
     Note:
+        Notation to SCITE paper:
         i = cell
         j = mutation
+        \\simga_j = sigma
+        D = mutation_mat
     """
+
+    def _compute_mutation_likelihood(mutation_status: int, ancestor: int) -> float:
+        """Returns the mutation likelihood.
+
+        Args:
+            mutation_status: mutation status of the cell - D_{ij}
+            ancestor: ancestor of the cell attached to the mutation node
+                    - A(T)_{i˜sigma_j}
+
+        Returns:
+            mutation likelihood - P(D_{ij} | A(T)_{i˜sigma_j})
+        """
+        # TODO: is this just a boolean?
+        # if mutation_status == 0 and ancestor == 0: 1
+        # if mutation_status == 1 and ancestor == 1: 1
+        # else: 0
+        # error rates don't matter here ?
+        raise NotImplementedError("Not implemented yet.")
+
     # A(T) - get ancestor matrix
     ancestor_mat = tr._get_ancestor_matrix(tree.tree_topology)
     # D_{ij} - mutation status
-    mutation_mat[cell, mutation]
+    mutation_status = mutation_mat[cell, mutation]
     # A(T)_{i˜sigma_j} - ancestor of cell i attached to node sigma_j
-    ancestor_mat[cell, sigma[mutation]]
+    ancestor = ancestor_mat[cell, sigma]
     # P(D_{ij} | A(T)_{i˜\delta_j})
+    mutation_likelihood = _compute_mutation_likelihood(mutation_status, ancestor)
 
-    # return likelihood
-    raise NotImplementedError("Not implemented yet.")
+    return mutation_likelihood

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -15,7 +15,7 @@ from pyggdrasil.tree_inference._interface import AncestorMatrix
 # Array of floats of shape (n, m, n+1) where n is the number of mutations,
 # m is the number of cells, and n+1 is the number of nodes in the tree.
 # The axis are (i=mutation, j=cell, k=attachment node)
-Mutation_Likelihood = jax.Array
+MutationLikelihood = jax.Array
 
 
 def logprobability_fn(
@@ -54,7 +54,7 @@ def _log_mutation_likelihood(
     tree: Tree,
     mutation_mat: MutationMatrix,
     theta: tuple[float, float],
-) -> Mutation_Likelihood:
+) -> MutationLikelihood:
     """Returns the log-likelihood of a cell / mutation /attachment.
 
     Args:
@@ -90,7 +90,7 @@ def _mutation_likelihood(
     mutation_matrix: MutationMatrix,
     ancestor_matrix: AncestorMatrix,
     theta: tuple[float, float],
-) -> Mutation_Likelihood:
+) -> MutationLikelihood:
     """Returns the mutation likelihood given the data and expected mutation matrix.
 
     Currently, only implements non-homozygous mutations.

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -45,7 +45,7 @@ def logprobability_fn(
     log_sum_exp = jsp.special.logsumexp(lse_arg, axis=-1)
 
     # sum_{j=1}^{m}
-    log_prob = jnp.einsum("j->", log_sum_exp)
+    log_prob = float(jnp.einsum("j->", log_sum_exp))
 
     return log_prob
 

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -3,11 +3,79 @@
 The log-probability functions are used to calculate the log-probability of a tree.
 """
 
+import pyggdrasil.tree_inference._tree as tr
+from pyggdrasil.tree_inference._tree import Tree
 
-def logprobability_fn():
+from pyggdrasil.tree_inference._interface import MutationMatrix, CellAttachmentVector
+
+
+def logprobability_fn(
+    data: MutationMatrix, tree: tr.Tree, theta: tuple[float, float]
+) -> float:
     """Returns a function that calculates the log-probability of a tree.
 
+    Args:
+        data: observed mutation matrix to calculate the log-probability of
+        tree: tree to calculate the log-probability of
+        theta: \theta = (\alpha, \beta) error rates
+
     Returns:
-        function that takes a tree and returns it's log-probability
+        log-probability of the tree
+        Implements the log-probability function from the paper: Equation 13
+        P(D|T,\theta) = \frac{T,\theta | D}{P(T,\theta)}
     """
+
+    # TODO: consider using jsps.special.logsumexp
+    # TODO: consider using jnp.einsum
+
+    # likelihood = None
+    #
+    # # P( \sigma_j | T, \theta)
+    # attch_prior = jnp.array([0.5, 0.5])  # TODO: implement this
+    # # prod_{i=1}^{n} P(D_{ij} | A(T)_{i˜sigma(j)})
+    # prod_cells_likelihood = jnp.prod(likelihood)
+    # # [prod_cells_likelihood] * attch_prior
+    # prod_cells_likelihood_attch_prior = prod_cells_likelihood * attch_prior
+    # # log sum_{\simga_j = 1}^{n+1}
+    # log_prob_cells = jsp.special.logsumexp(prod_cells_likelihood_attch_prior)
+    # # sum_{j=1}^{m}
+    # jnp.sum(log_prob_cells)
+
+    # result = jnp.einsum("ij,ij->i", likelihood, attch_prior)
+
+    raise NotImplementedError("Not implemented yet.")
+
+
+def single_likelihood(
+    cell: int,
+    mutation: int,
+    sigma: CellAttachmentVector,
+    tree: Tree,
+    mutation_mat: MutationMatrix,
+):
+    """Returns the log-likelihood of a cell / mutaiton.
+
+    Args:
+        cell: cell index
+        mutation: mutation index
+        sigma: mutation node the cell is attached to
+        tree: tree
+
+    Returns:
+        likelihood of the cell / mutation
+        prod_{i=1}^{n} P(D_{ij} | A(T)_{i˜sigma_j})
+
+    Note:
+        i = cell
+        j = mutation
+    """
+    # A(T) - get ancestor matrix
+    ancestor_mat = tr._get_ancestor_matrix(tree.tree_topology)
+    # D_{ij} - mutation status
+    mutation_mat[cell, mutation]
+    # A(T)_{i˜sigma_j} - ancestor of cell i attached to node sigma_j
+    ancestor_mat[cell, sigma[mutation]]
+    # P(D_{ij} | A(T)_{i˜\delta_j})
+
+    # return likelihood
     raise NotImplementedError("Not implemented yet.")

--- a/src/pyggdrasil/tree_inference/_logprob.py
+++ b/src/pyggdrasil/tree_inference/_logprob.py
@@ -153,9 +153,9 @@ def _mutation_likelihood(
     # A(T) - get ancestor matrix
     ancestor_mat = tr._get_ancestor_matrix(tree.tree_topology)
     # D_{ij} - mutation status
-    mutation_status = mutation_mat[cell, mutation]
+    mutation_status = int(mutation_mat[cell, mutation])
     # A(T)_{i˜sigma_j} - ancestor of cell i attached to node sigma_j
-    ancestor = ancestor_mat[cell, sigma]
+    ancestor = int(ancestor_mat[cell, sigma])
     # P(D_{ij} | A(T)_{i˜\delta_j})
     mutation_likelihood = _compute_mutation_likelihood(mutation_status, ancestor)
 
@@ -173,10 +173,10 @@ def _attachment_prior(
     Args:
         sigma: mutation node the cell is attached to
         tree: tree object contains the tree topology, labels
-        theta: \theta = (\alpha, \beta) error rates
+        theta: theta = (alpha, beta) error rates
 
     Returns:
-        attachment prior - P(\sigma_{j} |T, \theta)
+        attachment prior - P(sigma_{j} |T, theta)
     """
 
     # TODO: what is this even ? - uniform prior ? Just 1/ n (+1) ?

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -126,8 +126,7 @@ def _get_descendants(
       in order of nodes in the adjacency matrix, i.e. the order of the labels
       if includeParent is True, the parent is included in the list of descendants
     """
-    # get number of nodes
-    adj_matrix.shape[0]
+
     # get ancestor matrix
     ancestor_mat = _get_ancestor_matrix(adj_matrix)
     # get index of parent

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -127,9 +127,9 @@ def _get_descendants(
       if includeParent is True, the parent is included in the list of descendants
     """
     # get number of nodes
-    n = adj_matrix.shape[0]
+    adj_matrix.shape[0]
     # get ancestor matrix
-    ancestor_mat = _get_ancestor_matrix(adj_matrix, n)
+    ancestor_mat = _get_ancestor_matrix(adj_matrix)
     # get index of parent
     parent_idx = int(jnp.where(labels == parent)[0])
     # get descendants
@@ -167,7 +167,7 @@ def _expon_adj_mat(adj_matrix: Array, exp: int):
     return adj_matrix_exp
 
 
-def _get_ancestor_matrix(adj_matrix: Array, n: int):
+def _get_ancestor_matrix(adj_matrix: Array):
     """Returns the ancestor matrix.
 
     Complexity: O(n^4) where n is the number
@@ -205,7 +205,7 @@ def _get_root_label(tree: Tree) -> int:
             root label of the tree
     """
     # get ancestor matrix of tree
-    ancestor_matrix = _get_ancestor_matrix(tree.tree_topology, tree.labels.shape[0])
+    ancestor_matrix = _get_ancestor_matrix(tree.tree_topology)
     # find row which has all ones in ancestor_matrix
     root_idx = jnp.where(jnp.all(ancestor_matrix == 1, axis=1))[0]
     if len(root_idx) > 1:

--- a/tests/tree_inference/test_logprob.py
+++ b/tests/tree_inference/test_logprob.py
@@ -80,4 +80,58 @@ def test_compute_mutation_likelihood():
 
     # check total prob.
     total_sum = jnp.einsum("ijk->", mutation_likelihood)
-    assert int(total_sum) == 40
+    assert jnp.equal(total_sum, 40)
+
+
+def test_logprobability_fn():
+    """Test logprobability_fn manually."""
+    # define tree
+    adj_mat = jnp.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 1, 1, 0]])
+    labels = jnp.array([0, 1, 2, 3])
+    tree = Tree(adj_mat, labels)
+
+    # define mutation matrix
+    mutation_matrix = jnp.array([[0, 0, 0, 1, 0], [0, 0, 1, 1, 1], [0, 1, 0, 0, 0]])
+
+    # define error rates
+    alpha = 0.5
+    beta = 0.5
+    theta = (alpha, beta)
+    # should result in a (n)* (n+1) * (m) tensor or all elements 0.5
+
+    # expected
+    # manually compute expected logprob
+    expected = 5 * jnp.log(4 * jnp.exp(3 * jnp.log(0.5)))
+
+    # define logprob fn
+    log_prob = logprob.logprobability_fn(mutation_matrix, tree, theta)
+    assert jnp.equal(log_prob, expected)
+
+
+def test_logprobability_fn_direction():
+    """Test logprobability_fn, test if error in mutation matrix gives worse logprob."""
+    # define tree
+    adj_mat = jnp.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 1, 1, 0]])
+    labels = jnp.array([0, 1, 2, 3])
+    tree = Tree(adj_mat, labels)
+
+    # define mutation matrix
+    mutation_matrix_true = jnp.array(
+        [[0, 0, 0, 1, 0], [0, 0, 1, 1, 1], [0, 1, 0, 0, 0]]
+    )
+    mutation_matrix_false = jnp.array(
+        [[0, 0, 0, 0, 1], [1, 1, 1, 0, 0], [0, 0, 1, 0, 0]]
+    )
+
+    # define error rates
+    alpha = 0.1
+    beta = 0.3
+    theta = (alpha, beta)
+
+    # define logprob fn for true mutation matrix
+    log_prob_true = logprob.logprobability_fn(mutation_matrix_true, tree, theta)
+
+    # define logprob fn for false mutation matrix
+    log_prob_false = logprob.logprobability_fn(mutation_matrix_false, tree, theta)
+
+    assert log_prob_true > log_prob_false

--- a/tests/tree_inference/test_logprob.py
+++ b/tests/tree_inference/test_logprob.py
@@ -42,7 +42,7 @@ def test_compute_mutation_likelihood():
 
     # define mutation likelihoods
     # mutation_likelihoods = logprob._compute_mutation_likelihood(tree, ancestor_matrix)
-    mutation_likelihood = logprob._compute_mutation_likelihood(
+    mutation_likelihood = logprob._mutation_likelihood(
         mutation_matrix, ancestor_matrix, theta
     )
 
@@ -67,7 +67,7 @@ def test_compute_mutation_likelihood():
 
     # define mutation likelihoods
     # mutation_likelihoods = logprob._compute_mutation_likelihood(tree, ancestor_matrix)
-    mutation_likelihood = logprob._compute_mutation_likelihood(
+    mutation_likelihood = logprob._mutation_likelihood(
         mutation_matrix, ancestor_matrix, theta
     )
 

--- a/tests/tree_inference/test_logprob.py
+++ b/tests/tree_inference/test_logprob.py
@@ -1,0 +1,83 @@
+"""Tests of the log-probability calculations."""
+# _logprob.py
+
+import jax.numpy as jnp
+
+import pyggdrasil.tree_inference._logprob as logprob
+from pyggdrasil.tree_inference._tree import Tree
+import pyggdrasil.tree_inference._tree as tr
+
+
+def test_compute_mutation_likelihood():
+    """Test _compute_mutation_likelihood manually
+
+    Computes mutation likelihood given the true mutation matrix as data.
+    Sets error rates to alpha to 1 and also beta to 1 each, to check for
+    the correct total probability.
+    """
+
+    # define tree
+    adj_mat = jnp.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 1, 1, 0]])
+    labels = jnp.array([0, 1, 2, 3])
+    tree = Tree(adj_mat, labels)
+    ancestor_matrix = tr._get_ancestor_matrix(tree.tree_topology)
+    ancestor_matrix_truth = jnp.array(
+        [[1, 0, 0, 0], [1, 1, 0, 0], [0, 0, 1, 0], [1, 1, 1, 1]]
+    )
+
+    assert jnp.all(ancestor_matrix == ancestor_matrix_truth)
+
+    # cell attachment vector
+    # sigma = jnp.array([3, 2, 1 ,0, 1])
+    # get mutation matrix / data - get true mutation matrix
+    mutation_matrix = jnp.array([[0, 0, 0, 1, 0], [0, 0, 1, 1, 1], [0, 1, 0, 0, 0]])
+
+    # test for is mutation
+    # define error rates to check outcome
+    alpha = 1.0
+    beta = 0.0
+    theta = (alpha, beta)
+    # thus we expect only for data=1 and expected mutation=1 matrix probability of 1
+    # we expect 5 * n (=4) = 4 * j(=5) = 20 entries of unity in the final matrix
+
+    # define mutation likelihoods
+    # mutation_likelihoods = logprob._compute_mutation_likelihood(tree, ancestor_matrix)
+    mutation_likelihood = logprob._compute_mutation_likelihood(
+        mutation_matrix, ancestor_matrix, theta
+    )
+
+    # check shape
+    n = 4
+    m = 5
+    assert mutation_likelihood.shape == (n - 1, m, n)
+
+    print(mutation_likelihood[:, :, 0])
+
+    # check total prob.
+    total_sum = jnp.einsum("ijk->", mutation_likelihood)
+    assert int(total_sum) == 20
+
+    # test for is not mutation
+    # define error rates to check outcome
+    alpha = 0.0
+    beta = 1.0
+    theta = (alpha, beta)
+    # thus we expect only for data=0 and expected mutation=0 matrix probability of 1
+    # we expect 10 * n (=4) = 8 * j(=5) = 40 entries of unity in the final matrix
+
+    # define mutation likelihoods
+    # mutation_likelihoods = logprob._compute_mutation_likelihood(tree, ancestor_matrix)
+    mutation_likelihood = logprob._compute_mutation_likelihood(
+        mutation_matrix, ancestor_matrix, theta
+    )
+
+    # check shape
+    n = 4
+    m = 5
+    assert mutation_likelihood.shape == (n - 1, m, n)
+
+    print(mutation_likelihood[:, :, 0])
+
+    # check total prob.
+    total_sum = jnp.einsum("ijk->", mutation_likelihood)
+    assert int(total_sum) == 40


### PR DESCRIPTION
Implementing the `logprobability_fn`: function by taking a tree and returning its log-probability
          (up to the additive (log-)normalization constant).
          
As defined by Eqn. 13 in the SCITE paper.

Taking care of numerical stability using the  `logsumexp` trick.

Consider using `jnp.einsum`.

Resolves #19 