### PR TITLE
Add utilities from scPhylo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,10 @@ python = "^3.9"
 anytree = "^2.8.0"
 jax = "^0.4.4"
 jaxlib = "^0.4.4"
-numpy = "^1.24.2"
+numpy = "^1.23.0"
 typing-extensions = "^4.5.0"
+llvmlite = "^0.39.1"
+scphylo-tools = {git = "https://github.com/pawel-czyz/scphylo-tools.git"}
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/distances/test_scphylo_wrapper.py
+++ b/tests/distances/test_scphylo_wrapper.py
@@ -1,0 +1,32 @@
+"""Tests of distance and similarity functions
+imported from scphylo"""
+import numpy as np
+import pandas as pd
+import pytest
+import scphylo
+
+
+def test_basic() -> None:
+    """TEMPORARY: to be adjusted."""
+    genotypes = np.asarray(
+        [
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [1, 0, 0, 1],
+            [1, 0, 1, 0],
+            [0, 1, 0, 0],
+        ]
+    )
+
+    df = pd.DataFrame(genotypes)
+
+    df.columns = [str(x) for x in df.columns]
+    df.index = [str(x) for x in df.index]
+
+    sim = scphylo.tl.mp3(df, df)
+
+    assert sim == pytest.approx(1.0)
+
+    rec = scphylo.tl.huntress(df, 0.001, 0.001)
+
+    assert isinstance(rec, pd.DataFrame)


### PR DESCRIPTION
This PR adds a dependency on (a fork of) the scPhylo library. In particular, we can now:

  - Use distance/similarity functions.
  - Use tree inference methods as HUNTRESS.

Hence, it resolves #2 and #22.