### PR TITLE
Consistent naming of FNR and FPR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ matplotlib = "^3.7.1"
 xarray = "^2023.4.2"
 datetime = "^5.1"
 pytz = "^2023.3"
+pydantic = "^1.10.7"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/scripts/cell_simulation.py
+++ b/scripts/cell_simulation.py
@@ -11,7 +11,7 @@ Example Usage:
 poetry run python ../scripts/cell_simulation.py
 --seed 42
 --out_dir ../data --n_trees 3 --n_cells 100 --n_mutations 8
- --strategy UNIFORM_INCLUDE_ROOT --alpha 0.01 --beta 0.02
+ --strategy UNIFORM_INCLUDE_ROOT --fpr 0.01 --fnr 0.02
  --na_rate 0.01 --observe_homozygous True --verbose
 """
 
@@ -79,10 +79,8 @@ def create_parser() -> argparse.Namespace:
         default="UNIFORM_INCLUDE_ROOT",
     )
 
-    parser.add_argument(
-        "--alpha", required=True, help="False negative rate", type=float
-    )
-    parser.add_argument("--beta", required=True, help="False positive rate", type=float)
+    parser.add_argument("--fpr", required=True, help="False positive rate", type=float)
+    parser.add_argument("--fnr", required=True, help="False negative rate", type=float)
 
     parser.add_argument(
         "--na_rate", required=True, help="Missing entry rate", type=float
@@ -114,8 +112,8 @@ def compose_save_name(params: argparse.Namespace, *, tree_no: int) -> str:
         f"n_trees_{params.n_trees}_"
         f"n_cells_{params.n_cells}_"
         f"n_mutations_{params.n_mutations}_"
-        f"alpha_{params.alpha}_"
-        f"beta_{params.beta}_"
+        f"fpr_{params.fpr}_"
+        f"fnr_{params.fnr}_"
         f"na_rate_{params.na_rate}_"
         f"observe_homozygous_{params.observe_homozygous}_"
         f"strategy_{params.strategy}"

--- a/scripts/cell_simulation.py
+++ b/scripts/cell_simulation.py
@@ -25,6 +25,7 @@ import os
 
 import pyggdrasil.tree_inference as tree_inf
 
+from pyggdrasil.tree_inference import CellSimulationModel
 from pyggdrasil.serialize import JnpEncoder
 
 
@@ -145,11 +146,12 @@ def gen_sim_data(
     # Parameters
     ############################################################################
     params_dict = vars(params)
+    params_model = CellSimulationModel(**params_dict)
 
     ############################################################################
     # Generate Data
     ############################################################################
-    data = tree_inf.gen_sim_data(params_dict, rng)
+    data = tree_inf.gen_sim_data(params_model, rng)
 
     ################################################################################
     # Save Simulation Results

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -10,6 +10,7 @@ from pyggdrasil.tree_inference._simulate import (
     adjacency_to_root_dfs,
     get_descendants,
     gen_sim_data,
+    CellSimulationModel,
 )
 
 from pyggdrasil.tree_inference._mcmc_sampler import mcmc_sampler, MoveProbabilities
@@ -42,4 +43,5 @@ __all__ = [
     "unpack_sample",
     "gen_sim_data",
     "huntress_tree_inference",
+    "CellSimulationModel",
 ]

--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -52,5 +52,5 @@ CellAttachmentVector = Array
 AncestorMatrix = Array
 
 # Observational Error rates
-# tuple of (alpha, beta)
+# tuple of (fpr, fnr)
 ErrorRates = tuple[float, float]

--- a/src/pyggdrasil/tree_inference/_mcmc_sampler.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_sampler.py
@@ -47,7 +47,7 @@ def mcmc_sampler(
     Args:
         rng_key: random key for the MCMC sampler
         init_tree: initial tree to start the MCMC sampler from
-        error_rates: \theta = (\alpha, \beta) error rates
+        error_rates: \theta = (\fpr, \fnr) error rates
         move_probs: probabilities for each move
         data: observed mutation matrix to calculate the log-probability of,
             given current tree

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -587,7 +587,7 @@ def adjacency_to_root_dfs(
     return root
 
 
-class CellSimulationParams(TypedDict):
+class CellSimulationParams(TypedDict, total=True):
     """Cell Simulation Parameters."""
 
     n_cells: int

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -9,7 +9,7 @@ import pyggdrasil.serialize as serialize
 import pyggdrasil.tree_inference._interface as interface
 from pyggdrasil.tree import TreeNode
 
-from typing import Union
+from typing import Union, TypedDict
 from jax import Array
 
 # Mutation matrix without noise
@@ -587,15 +587,27 @@ def adjacency_to_root_dfs(
     return root
 
 
+class CellSimulationParams(TypedDict):
+    """Cell Simulation Parameters."""
+
+    n_cells: int
+    n_mutations: int
+    fpr: float
+    fnr: float
+    na_rate: float
+    observe_homozygous: bool
+    strategy: str
+
+
 def gen_sim_data(
-    params: dict,
+    params: CellSimulationParams,
     rng: interface.JAXRandomKey,
 ) -> dict:
     """
     Generates cell mutation matrix for one tree.
 
     Args:
-        params: input parameters from parser
+        params: TypedDict from parser of cell_simulation.py
             input parameters from parser for simulation
         rng: JAX random number generator
     Returns:

--- a/tests/tree_inference/test_simulate.py
+++ b/tests/tree_inference/test_simulate.py
@@ -464,7 +464,7 @@ def test_gen_sim_data():
 
     rng = random.PRNGKey(params["seed"])
 
-    params_ty = sim.CellSimulationParams(**params)
+    params_ty = sim.CellSimulationModel(**params)
 
     data = sim.gen_sim_data(params_ty, rng)
 

--- a/tests/tree_inference/test_simulate.py
+++ b/tests/tree_inference/test_simulate.py
@@ -456,15 +456,17 @@ def test_gen_sim_data():
     params["seed"] = 42
     params["n_cells"] = 100
     params["n_mutations"] = 8
-    params["alpha"] = 0.01
-    params["beta"] = 0.02
+    params["fpr"] = 0.01
+    params["fnr"] = 0.02
     params["na_rate"] = 0.01
     params["observe_homozygous"] = True
     params["strategy"] = "UNIFORM_INCLUDE_ROOT"
 
     rng = random.PRNGKey(params["seed"])
 
-    data = sim.gen_sim_data(params, rng)
+    params_ty = sim.CellSimulationParams(**params)
+
+    data = sim.gen_sim_data(params_ty, rng)
 
     # check that the dimensions of the data are correct
     assert np.array(data["adjacency_matrix"]).shape == (8 + 1, 8 + 1)

--- a/workflows/Snakefile
+++ b/workflows/Snakefile
@@ -7,8 +7,8 @@ params_md["n_tree"] = 3
 params_md["n_cells"] = 500
 params_md["n_mutations"] = 8
 params_md["strategy"] = ["""UNIFORM_INCLUDE_ROOT""", """UNIFORM_EXCLUDE_ROOT"""]
-params_md["alpha"] = 1.24*10**(-6)
-params_md["beta"] = 0.097
+params_md["fpr"] = 1.24*10**(-6)
+params_md["fnr"] = 0.097
 params_md["na_rate"] = 0.014
 params_md["observe_homozygous"] = ["False", "True"]
 
@@ -16,14 +16,14 @@ params_md["observe_homozygous"] = ["False", "True"]
 rule all:
     """Run all."""
     input:
-        mock_data = expand('../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_alpha_{alpha}_beta_{beta}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json',
+        mock_data = expand('../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_fpr_{fpr}_fnr_{fnr}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json',
                             seed=params_md["seed"],
                             n_trees=params_md["n_tree"],
                             n_cells=params_md["n_tree"],
                             n_mutations=params_md["n_mutations"],
                             strategy=params_md["strategy"],
-                            alpha=params_md["alpha"],
-                            beta=params_md["beta"],
+                            fpr=params_md["fpr"],
+                            fnr=params_md["fnr"],
                             na_rate=params_md["na_rate"],
                             observe_homozygous=params_md["observe_homozygous"],
                             tree_no= list(range(1, params_md["n_tree"]+1))
@@ -36,14 +36,14 @@ rule all:
 rule parametrize_mock_data:
     """Define parameterization of mock data generation."""
     input:
-        expand('../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_alpha_{alpha}_beta_{beta}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json',
+        expand('../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_fpr_{fpr}_fnr_{fnr}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json',
             seed=params_md["seed"],
             n_trees=params_md["n_tree"],
             n_cells=params_md["n_tree"],
             n_mutations=params_md["n_mutations"],
             strategy=params_md["strategy"],
-            alpha=params_md["alpha"],
-            beta=params_md["beta"],
+            fpr=params_md["fpr"],
+            fnr=params_md["fnr"],
             na_rate=params_md["na_rate"],
             observe_homozygous=params_md["observe_homozygous"],
             tree_no= list(range(1, params_md["n_tree"]+1))
@@ -55,7 +55,7 @@ rule generate_mock_data:
     input:
         script = "../scripts/cell_simulation.py"
     output:
-        mock_data = '../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_alpha_{alpha}_beta_{beta}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json'
+        mock_data = '../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_fpr_{fpr}_fnr_{fnr}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json'
     params:
         seed = lambda wildcards,input: wildcards.seed,
         out_dir = "../data/mock",
@@ -63,8 +63,8 @@ rule generate_mock_data:
         n_cells = lambda wildcards,input: wildcards.n_cells,
         n_mutations = lambda wildcards,input: wildcards.n_mutations,
         strategy = lambda wildcards,input: wildcards.strategy,
-        alpha = lambda wildcards,input: wildcards.alpha,
-        beta = lambda wildcards,input: wildcards.beta,
+        fpr = lambda wildcards,input: wildcards.fpr,
+        fnr = lambda wildcards,input: wildcards.fnr,
         na_rate = lambda wildcards,input: wildcards.na_rate,
         observe_homozygous = lambda wildcards,input: wildcards.observe_homozygous
     shell:
@@ -76,8 +76,8 @@ rule generate_mock_data:
             --n_cells {params.n_cells} \
             --n_mutations {params.n_mutations} \
             --strategy {params.strategy} \
-            --alpha {params.alpha} \
-            --beta {params.beta} \
+            --fpr {params.fpr} \
+            --fnr {params.fnr} \
             --na_rate {params.na_rate} \
             --observe_homozygous {params.observe_homozygous} 
         """
@@ -90,8 +90,8 @@ params_mcmc["n_trees"] = 1
 params_mcmc["n_cells"] = 2000
 params_mcmc["n_mutations"] = 50
 params_mcmc["strategy"] = """UNIFORM_INCLUDE_ROOT"""
-params_mcmc["alpha"] = 1.24*10**(-6)
-params_mcmc["beta"] = 0.097
+params_mcmc["fpr"] = 1.24*10**(-6)
+params_mcmc["fnr"] = 0.097
 params_mcmc["na_rate"] = 0.014
 params_mcmc["observe_homozygous"] = "False"
 
@@ -99,14 +99,14 @@ rule run_mcmc_mark00:
     """Run MCMC on mock data."""
     input:
         script = "../scripts/run_mcmc.py",
-        data =  expand('../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_alpha_{alpha}_beta_{beta}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json',
+        data =  expand('../data/mock/seed_{seed}_n_trees_{n_trees}_n_cells_{n_cells}_n_mutations_{n_mutations}_fpr_{fpr}_fnr_{fnr}_na_rate_{na_rate}_observe_homozygous_{observe_homozygous}_strategy_{strategy}_tree_{tree_no}.json',
                         seed=params_mcmc["seed"],
                         n_trees=params_mcmc["n_trees"],
                         n_cells=params_mcmc["n_cells"],
                         n_mutations=params_mcmc["n_mutations"],
                         strategy=params_mcmc["strategy"],
-                        alpha=params_mcmc["alpha"],
-                        beta=params_mcmc["beta"],
+                        fpr=params_mcmc["fpr"],
+                        fnr=params_mcmc["fnr"],
                         na_rate=params_mcmc["na_rate"],
                         observe_homozygous=params_mcmc["observe_homozygous"],
                         tree_no= 1


### PR DESCRIPTION
> In the original SCITE paper stands for FPR (false positive rate) and stands for FNR (false negative rate).
>  
>  It'd be good to go through the code and see whether the naming is consistent. I'd also perhaps suggest dropping 
>  and notation entirely and use fpr and fnr instead.

see / resolves Issue #30 