### PR TITLE
Unify conventions of mutation matrices

### DIFF
--- a/src/pyggdrasil/tree_inference/_huntress.py
+++ b/src/pyggdrasil/tree_inference/_huntress.py
@@ -6,9 +6,11 @@ import pandas as pd
 import scphylo
 import pyggdrasil._scphylo_utils as utils
 
+from pyggdrasil.tree_inference import MutationMatrix
+
 
 def huntress_tree_inference(
-    mutations: np.ndarray,
+    mutation_mat: MutationMatrix,
     false_positive_rate: float,
     false_negative_rate: float,
     n_threads: int = 1,
@@ -16,9 +18,9 @@ def huntress_tree_inference(
     """Runs the HUNTRESS algorithm.
 
     Args:
-        mutations: binary array with entries 0 or 1,
+        mutation_mat: binary array with entries 0 or 1,
           depending on whether the mutation is present or not.
-          Shape (n_cells, n_sites)
+          Shape (n_sites, n_cells)
         false_positive_rate: false positive rate, in [0, 1)
         false_negative_rate: false negative rate, in [0, 1)
         n_threads: number of threads to be used, default 1
@@ -39,7 +41,12 @@ def huntress_tree_inference(
     assert 0 <= false_positive_rate < 1
     assert 0 <= false_negative_rate < 1
 
-    n_cells, n_mutations = mutations.shape
+    # check that all entries are either 0 or 1 else throw error
+    if not np.all(np.logical_or(mutation_mat == 0, mutation_mat == 1)):
+        raise Exception("Huntress does not allow with missing data.")
+
+    n_mutations, n_cells = mutation_mat.shape
+    mutations = mutation_mat.T
 
     mutations_dataframe = pd.DataFrame(
         mutations, columns=[str(i) for i in range(n_mutations)]

--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -25,10 +25,9 @@ Array = Union[jax.Array, np.ndarray]
 # i.e. [0,0,...0,0,1]
 TreeAdjacencyMatrix = Array
 
-# Represents mutations in sampled cells (n_cells, n_sites)
+# Represents mutations in sampled cells (n_sites, n_cells)
 # with n_cell columns, and n_site rows
-# where the last row is the root node, and its cells attached
-# i.e. M[-1,:] is an all one vector
+# (i.e. each row is a site, no root), and its cells attached
 MutationMatrix = Array
 # Apart from 0 (no mutation) and 1 (mutation present) we can observe these values
 # in the experimentally obtained matrices:

--- a/tests/tree_inference/test_huntress.py
+++ b/tests/tree_inference/test_huntress.py
@@ -38,7 +38,8 @@ def model_genotype() -> np.ndarray:
     # Generate more cells
     n_copies = 4
     matrix = np.vstack([mini_matrix for _ in range(n_copies)])
-
+    # Transpose to get the correct shape (n_sites, n_cells)
+    matrix = matrix.T
     return matrix
 
 


### PR DESCRIPTION
Adjust the definition of the `tree_inference.MutationMatrix` to be:

(n_mutations, n_cells) without the root
In this format each cell has its own rows and sequenced sites are in different columns.
It seems that this is the input format of [SCITE](https://github.com/cbg-ethz/SCITE).

Resolves: Issue. #31 