### PR TITLE
Resolve dependency issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ xarray = "^2023.4.2"
 datetime = "^5.1"
 pytz = "^2023.3"
 pydantic = "^1.10.7"
-
+cyvcf2 = "<0.30.20"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ xarray = "^2023.4.2"
 datetime = "^5.1"
 pytz = "^2023.3"
 pydantic = "^1.10.7"
-cyvcf2 = "<0.30.20"
+cyvcf2 = "<0.30.20"  # Temporary dependency: see https://github.com/cbg-ethz/PYggdrasil/pull/40/
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The problem was with `cyvcf2` dependency, which yesterday was updated from 0.3.19 to 0.3.20, causing our build to fail. Hence, we temporary pin it to 0.3.19, hoping that the issue will be resolved over the next few weeks.