### PR TITLE
Healing the tree of life - fixing _swap_subtrees_move_ for same lineage moves. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ datetime = "^5.1"
 pytz = "^2023.3"
 pydantic = "^1.10.7"
 cyvcf2 = "<0.30.20"  # Temporary dependency: see https://github.com/cbg-ethz/PYggdrasil/pull/40/
+tqdm = "^4.65.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -28,7 +28,7 @@ import logging
 
 
 from pathlib import Path
-
+from tqdm import tqdm
 
 import pyggdrasil.serialize as serialize
 import pyggdrasil.tree_inference as tree_inf
@@ -97,14 +97,10 @@ def main() -> None:
     fullpath_d = Path(args.data_fp)
     # plot the trees
     mcmc_samples = serialize.read_mcmc_samples(fullpath=fullpath_d)
-    print(mcmc_samples)
     pure_data = tree_inf.to_pure_mcmc_data(mcmc_samples)
 
     # get iterations
     iterations = pure_data.iterations
-    print(iterations)
-    print(len(iterations))
-    print(len(pure_data.trees))
 
     # print options
     print_options = dict()
@@ -112,34 +108,29 @@ def main() -> None:
     print_options["data_tree"] = dict()
     print_options["data_tree"]["log-likelihood"] = True
 
-    j = 0
     # for each iteration, plot the tree
-    for i in iterations:
-        i = int(i)
-        j += 1
-        print("j = ", j)
-        print(i)
+    for i in tqdm(iterations):
         # get the sample
         sample = pure_data.get_sample(i)
-        print(sample)
         # get the tree
         tree = sample[1]
-        tree.print_topo()
         tree.data = dict()
         tree.data["log-likelihood"] = sample[2]
         # get the log probability, and round to 2 decimal places
         log_prob = sample[2]
         log_prob = round(log_prob, 2)
-        # make savename from iteration number
+        # make save name from iteration number
 
-        save_name = "iteration_" + str(i) + "_log_prob_" + str(log_prob) + ".svg"
+        save_name = "iter_" + str(i) + "_log_prob_" + str(log_prob)
 
         # make full path with pathlib
         save_dir = Path(args.out_dir)
 
         # plot tree
         visualize.plot(tree, save_name, save_dir, print_options)
-
+        # log
+        logging.info("Plotted tree for iteration %s", i)
+    # log end
     logging.info("End Session")
 
 

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -101,7 +101,6 @@ def main() -> None:
     iterations = pure_data.iterations
     # convert iterations to list of integers
     iterations = list(map(int, iterations))
-
     # print options
     print_options = dict()
     print_options["title"] = False

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -7,19 +7,9 @@ Example Usage:
 poetry run python ../scripts/plot_trees.py
 
 Example Usage with arguments:
-    poetry run python scripts/run_mcmc.py
-    --config_fp data/config/mcmc_config_mark00.json
-    --out_dir data/mcmc/mark01
-    --data_fp data/mock/seed_32_n_..._tree_3.json
-
-    if you want to provide a tree:
-    from a mcmc run:
-    --init_tree_fp data/mcmc/mark01/samples_XXXXXXXX_XXXXXX.json
-    --iteration 1000
-    or to read in a TreeNode
-    --init_tree_fp data/trees/tree_3.json
-    --init_TreeNode
-
+    poetry run python scripts/plot_trees.py
+    --out_dir data/plots/tree/mark00
+    --data_fp data/mcmc/mark00/samples.json
 
 """
 

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -75,11 +75,17 @@ def main() -> None:
     # if logfile does not exist, create it
     if not Path(fullpath_log).exists():
         Path(fullpath_log).touch()
-    logging.basicConfig(filename=fullpath_log, level=logging.DEBUG)
+    # if logfile exist delete it and create a new one
+    else:
+        Path(fullpath_log).unlink()
+        Path(fullpath_log).touch()
+
+    logging.basicConfig(filename=fullpath_log, level=logging.INFO)
     # set logging level for jax
     logging.getLogger("jax._src.dispatch").setLevel(logging.ERROR)
     logging.getLogger("jax._src.interpreters.pxla").setLevel(logging.ERROR)
     logging.getLogger("jax._src.xla_bridge").setLevel(logging.ERROR)
+    logging.getLogger("matplotlib.texmanager").setLevel(logging.ERROR)
 
     logging.info("Starting Session")
 

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -74,18 +74,13 @@ def main() -> None:
     # get the full path
     out_dir = Path(args.out_dir)
     # if out_dir does not exist, create it
-    if not out_dir.exists():
-        out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     # Set up logging
     fullpath_log = out_dir / "plot_trees.log"
     # if logfile does not exist, create it
-    if not Path(fullpath_log).exists():
-        Path(fullpath_log).touch()
-    # if logfile exist delete it and create a new one
-    else:
-        Path(fullpath_log).unlink()
-        Path(fullpath_log).touch()
+    Path(fullpath_log).unlink(missing_ok=True)
+    Path(fullpath_log).touch()
 
     logging.basicConfig(filename=fullpath_log, level=logging.INFO)
     # set logging level for jax

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -103,17 +103,22 @@ def main() -> None:
     # get iterations
     iterations = pure_data.iterations
     print(iterations)
+    print(len(iterations))
+    print(len(pure_data.trees))
 
     # print options
     print_options = dict()
-    print_options["title"] = True
+    print_options["title"] = False
     print_options["data_tree"] = dict()
     print_options["data_tree"]["log-likelihood"] = True
-    print_options["data_tree"]["Data type"] = False
-    print_options["data_tree"]["Run"] = False
 
+    j = 0
     # for each iteration, plot the tree
     for i in iterations:
+        i = int(i)
+        j += 1
+        print("j = ", j)
+        print(i)
         # get the sample
         sample = pure_data.get_sample(i)
         print(sample)
@@ -122,14 +127,15 @@ def main() -> None:
         tree.print_topo()
         tree.data = dict()
         tree.data["log-likelihood"] = sample[2]
-        # get the log probability
+        # get the log probability, and round to 2 decimal places
         log_prob = sample[2]
+        log_prob = round(log_prob, 2)
         # make savename from iteration number
 
         save_name = "iteration_" + str(i) + "_log_prob_" + str(log_prob) + ".svg"
 
         # make full path with pathlib
-        save_dir = Path(args.out_dir).joinpath(save_name)
+        save_dir = Path(args.out_dir)
 
         # plot tree
         visualize.plot(tree, save_name, save_dir, print_options)

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -49,6 +49,13 @@ def create_parser() -> argparse.Namespace:
         type=str,
     )
 
+    parser.add_argument(
+        "--progress_bar_off",
+        required=False,
+        help="Turn off the progress bar",
+        action="store_true",
+    )
+
     args = parser.parse_args()
 
     return args
@@ -105,7 +112,7 @@ def main() -> None:
     print_options["data_tree"]["log-likelihood"] = True
 
     # for each iteration, plot the tree
-    for i in tqdm(iterations):
+    for i in tqdm(iterations, disable=args.progress_bar_off):
         i = int(i)
         # get the sample
         sample = pure_data.get_sample(i)

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -110,6 +110,7 @@ def main() -> None:
 
     # for each iteration, plot the tree
     for i in tqdm(iterations):
+        i = int(i)
         # get the sample
         sample = pure_data.get_sample(i)
         # get the tree

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -99,6 +99,8 @@ def main() -> None:
 
     # get iterations
     iterations = pure_data.iterations
+    # convert iterations to list of integers
+    iterations = list(map(int, iterations))
 
     # print options
     print_options = dict()
@@ -108,7 +110,6 @@ def main() -> None:
 
     # for each iteration, plot the tree
     for i in tqdm(iterations, disable=args.progress_bar_off):
-        i = int(i)
         # get the sample
         sample = pure_data.get_sample(i)
         # get the tree

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -79,8 +79,8 @@ def main() -> None:
     # Set up logging
     fullpath_log = out_dir / "plot_trees.log"
     # if logfile does not exist, create it
-    Path(fullpath_log).unlink(missing_ok=True)
-    Path(fullpath_log).touch()
+    fullpath_log.unlink(missing_ok=True)
+    fullpath_log.touch()
 
     logging.basicConfig(filename=fullpath_log, level=logging.INFO)
     # set logging level for jax

--- a/scripts/plot_trees.py
+++ b/scripts/plot_trees.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Plots all trees from an MCMC run.
+
+Example Usage:
+poetry run python ../scripts/plot_trees.py
+
+Example Usage with arguments:
+    poetry run python scripts/run_mcmc.py
+    --config_fp data/config/mcmc_config_mark00.json
+    --out_dir data/mcmc/mark01
+    --data_fp data/mock/seed_32_n_..._tree_3.json
+
+    if you want to provide a tree:
+    from a mcmc run:
+    --init_tree_fp data/mcmc/mark01/samples_XXXXXXXX_XXXXXX.json
+    --iteration 1000
+    or to read in a TreeNode
+    --init_tree_fp data/trees/tree_3.json
+    --init_TreeNode
+
+
+"""
+
+import argparse
+import logging
+
+
+from pathlib import Path
+
+
+import pyggdrasil.serialize as serialize
+import pyggdrasil.tree_inference as tree_inf
+import pyggdrasil.visualize as visualize
+
+
+def create_parser() -> argparse.Namespace:
+    """
+    Parser for required input user.
+
+    Returns:
+        args: argparse.Namespace
+    """
+
+    parser = argparse.ArgumentParser(description="Plot trees from MCMC sample.")
+
+    parser.add_argument(
+        "--out_dir",
+        required=True,
+        help="Output directory to save the tree plots.",
+        type=str,
+    )
+
+    parser.add_argument(
+        "--data_fp",
+        required=True,
+        help="File path containing the mcmc samples.",
+        type=str,
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main() -> None:
+    """
+    Main function for plotting trees from MCMC samples.
+
+    Returns:
+        None
+    """
+
+    args = create_parser()
+
+    # get the full path
+    out_dir = Path(args.out_dir)
+    # if out_dir does not exist, create it
+    if not out_dir.exists():
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set up logging
+    fullpath_log = out_dir / "plot_trees.log"
+    # if logfile does not exist, create it
+    if not Path(fullpath_log).exists():
+        Path(fullpath_log).touch()
+    logging.basicConfig(filename=fullpath_log, level=logging.DEBUG)
+    # set logging level for jax
+    logging.getLogger("jax._src.dispatch").setLevel(logging.ERROR)
+    logging.getLogger("jax._src.interpreters.pxla").setLevel(logging.ERROR)
+    logging.getLogger("jax._src.xla_bridge").setLevel(logging.ERROR)
+
+    logging.info("Starting Session")
+
+    # get the full path
+    fullpath_d = Path(args.data_fp)
+    # plot the trees
+    mcmc_samples = serialize.read_mcmc_samples(fullpath=fullpath_d)
+    print(mcmc_samples)
+    pure_data = tree_inf.to_pure_mcmc_data(mcmc_samples)
+
+    # get iterations
+    iterations = pure_data.iterations
+    print(iterations)
+
+    # print options
+    print_options = dict()
+    print_options["title"] = True
+    print_options["data_tree"] = dict()
+    print_options["data_tree"]["log-likelihood"] = True
+    print_options["data_tree"]["Data type"] = False
+    print_options["data_tree"]["Run"] = False
+
+    # for each iteration, plot the tree
+    for i in iterations:
+        # get the sample
+        sample = pure_data.get_sample(i)
+        print(sample)
+        # get the tree
+        tree = sample[1]
+        tree.print_topo()
+        tree.data = dict()
+        tree.data["log-likelihood"] = sample[2]
+        # get the log probability
+        log_prob = sample[2]
+        # make savename from iteration number
+
+        save_name = "iteration_" + str(i) + "_log_prob_" + str(log_prob) + ".svg"
+
+        # make full path with pathlib
+        save_dir = Path(args.out_dir).joinpath(save_name)
+
+        # plot tree
+        visualize.plot(tree, save_name, save_dir, print_options)
+
+    logging.info("End Session")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_mcmc.py
+++ b/scripts/run_mcmc.py
@@ -152,6 +152,14 @@ def get_mutation_matrix(data_fp: str) -> MutationMatrix:
             observed mutation matrix
     """
 
+    # check if file exists, else raise error
+    if not Path(data_fp).is_file():
+        raise FileNotFoundError(f"File not found: {data_fp}")
+
+    # check that file is not empty
+    if Path(data_fp).stat().st_size == 0:
+        raise ValueError(f"File is empty: {data_fp}")
+
     # load data from file to json object
     with open(data_fp, "r") as f:
         data = json.load(f)

--- a/scripts/run_mcmc.py
+++ b/scripts/run_mcmc.py
@@ -328,7 +328,12 @@ def main() -> None:
     if not Path(fullpath).exists():
         Path(fullpath).touch()
     # Set up logging
-    logging.basicConfig(filename=fullpath, level=logging.INFO)
+    logging.basicConfig(filename=fullpath, level=logging.DEBUG)
+    # set logging level for jax
+    logging.getLogger("jax._src.dispatch").setLevel(logging.ERROR)
+    logging.getLogger("jax._src.interpreters.pxla").setLevel(logging.ERROR)
+    logging.getLogger("jax._src.xla_bridge").setLevel(logging.ERROR)
+
     logging.info("Starting Session")
 
     logging.info(f"Configuration:/ {config}")

--- a/scripts/run_mcmc.py
+++ b/scripts/run_mcmc.py
@@ -328,7 +328,7 @@ def main() -> None:
     if not Path(fullpath).exists():
         Path(fullpath).touch()
     # Set up logging
-    logging.basicConfig(filename=fullpath, level=logging.DEBUG)
+    logging.basicConfig(filename=fullpath, level=logging.INFO)
     # set logging level for jax
     logging.getLogger("jax._src.dispatch").setLevel(logging.ERROR)
     logging.getLogger("jax._src.interpreters.pxla").setLevel(logging.ERROR)

--- a/src/pyggdrasil/interface/__init__.py
+++ b/src/pyggdrasil/interface/__init__.py
@@ -32,7 +32,16 @@ MCMCSample = xr.Dataset
 
 @dataclass
 class PureMcmcData:
-    """Pure MCMC data - easy to plot."""
+    """Pure MCMC data
+
+    Attributes:
+        iterations: jax.Array
+                iteration numbers
+        trees: list[TreeNode]
+                list of TreeNode objects
+        log_probabilities: jax.Array
+                log-probabilities of the trees
+    """
 
     iterations: jax.Array
     trees: list[TreeNode]

--- a/src/pyggdrasil/interface/__init__.py
+++ b/src/pyggdrasil/interface/__init__.py
@@ -56,10 +56,13 @@ class PureMcmcData:
             tree: TreeNode object
             log_probability: log-probability of the tree
         """
+        # get index of iteration
+        iteration_idx = jnp.where(self.iterations == iteration)[0][0]
+
         return (
             iteration,
-            self.trees[iteration],
-            self.log_probabilities[iteration].item(),
+            self.trees[iteration_idx],
+            self.log_probabilities[iteration_idx].item(),
         )
 
     def append(self, iteration: int, tree: TreeNode, log_probability: float):

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -25,6 +25,7 @@ from pyggdrasil.tree_inference._mcmc_util import unpack_sample
 
 from pyggdrasil.tree_inference._huntress import huntress_tree_inference
 
+from pyggdrasil.tree_inference._analyze import to_pure_mcmc_data, check_run_for_tree
 
 __all__ = [
     "CellAttachmentStrategy",
@@ -44,4 +45,6 @@ __all__ = [
     "gen_sim_data",
     "huntress_tree_inference",
     "CellSimulationModel",
+    "to_pure_mcmc_data",
+    "check_run_for_tree",
 ]

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -8,22 +8,25 @@ from pyggdrasil.tree_inference._simulate import (
     shortest_path_to_ancestry_matrix,
     generate_random_tree,
     adjacency_to_root_dfs,
-    get_descendants,
+    get_descendants_fw,
     gen_sim_data,
     CellSimulationModel,
 )
 
-from pyggdrasil.tree_inference._mcmc_sampler import mcmc_sampler, MoveProbabilities
-
 from pyggdrasil.tree_inference._interface import (
     MutationMatrix,
+    JAXRandomKey,
+    ErrorRates,
+    TreeAdjacencyMatrix,
 )
 
-from pyggdrasil.tree_inference._tree import Tree, tree_from_tree_node
+from pyggdrasil.tree_inference._tree import Tree, tree_from_tree_node, get_descendants
 
 from pyggdrasil.tree_inference._mcmc_util import unpack_sample
 
 from pyggdrasil.tree_inference._huntress import huntress_tree_inference
+
+from pyggdrasil.tree_inference._mcmc_sampler import mcmc_sampler, MoveProbabilities
 
 from pyggdrasil.tree_inference._analyze import to_pure_mcmc_data, check_run_for_tree
 
@@ -35,7 +38,7 @@ __all__ = [
     "shortest_path_to_ancestry_matrix",
     "generate_random_tree",
     "adjacency_to_root_dfs",
-    "get_descendants",
+    "get_descendants_fw",
     "mcmc_sampler",
     "MutationMatrix",
     "Tree",
@@ -47,4 +50,9 @@ __all__ = [
     "CellSimulationModel",
     "to_pure_mcmc_data",
     "check_run_for_tree",
+    "JAXRandomKey",
+    "ErrorRates",
+    "TreeAdjacencyMatrix",
+    "get_descendants",
+    "get_descendants_fw",
 ]

--- a/src/pyggdrasil/tree_inference/_analyze.py
+++ b/src/pyggdrasil/tree_inference/_analyze.py
@@ -2,11 +2,16 @@
 
 import jax.numpy as jnp
 from typing import Union
+import logging
 
 from pyggdrasil import TreeNode, compare_trees
 from pyggdrasil.tree_inference import Tree, unpack_sample
 
 from pyggdrasil.interface import MCMCSample, PureMcmcData
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def to_pure_mcmc_data(mcmc_samples: list[MCMCSample]) -> PureMcmcData:
@@ -29,6 +34,7 @@ def to_pure_mcmc_data(mcmc_samples: list[MCMCSample]) -> PureMcmcData:
     log_probabilities = jnp.empty(mcmc_samples_len)
 
     for index, sample in enumerate(mcmc_samples):
+        logger.debug(f"converting sample of index: {index}")
         iteration, tree, logprobability = unpack_sample(sample)
         iterations = iterations.at[index].set(iteration)
         trees.append(tree.to_TreeNode())

--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -259,131 +259,6 @@ def _detach_subtrees(
     return new_adj_mat, parent1_idx, parent2_idx, node1_idx, node2_idx
 
 
-def _swap_subtrees_move(
-    tree: Tree,
-    node1: int,
-    node2: int,
-    same_lineage: bool,
-    key: random.PRNGKeyArray = None,
-) -> Tree:
-    """Swaps subtrees rooted at ``node1``/ ``node i`` and ``node2``/ ``node k``.
-
-    Args:
-        tree: original tree from which we will build a new sample
-        node1: root of the first subtree
-        node2: root of the second subtree
-    Returns:
-        new tree
-
-    Note: - assumes `node1``/ ``node i`` not child of ``node2``/ ``node k``.
-    """
-    # get node indices
-    node1_idx = jnp.where(tree.labels == node1)[0]
-    node2_idx = jnp.where(tree.labels == node2)[0]
-    # get parent of node1
-    parent1_idx = jnp.where(tree.tree_topology[:, node1_idx] == 1)[0]
-    # get parent of node2
-    parent2_idx = jnp.where(tree.tree_topology[:, node2_idx] == 1)[0]
-    # detach subtree 1
-    new_adj_mat = tree.tree_topology.at[parent1_idx, node1_idx].set(0)
-    # detach subtree 2
-    new_adj_mat = new_adj_mat.at[parent2_idx, node2_idx].set(0)
-
-    if not same_lineage:
-        # attach subtree 1 to parent of node2
-        new_adj_mat = new_adj_mat.at[parent2_idx, node1_idx].set(1)
-        # attach subtree 2 to parent of node1
-        new_adj_mat = new_adj_mat.at[parent1_idx, node2_idx].set(1)
-        # make new tree
-        new_tree = Tree(tree_topology=new_adj_mat, labels=tree.labels)
-
-        logger.debug(
-            "MCMC: Swap subtrees move - swapped subtrees rooted at node %s and node %s",
-            node1,
-            node2,
-        )
-        return new_tree
-
-    # if same lineage
-    else:
-        # attach subtree of k to parent of i -
-        # i.e. attach parent of node i/1 to node k/2
-        new_adj_mat = new_adj_mat.at[parent1_idx, node2_idx].set(1)
-        # get descendants of node k including k itself,
-        # as possible nodes attach node i to
-        descendants = get_descendants(
-            tree.tree_topology, tree.labels, node2, include_parent=True
-        )
-        # sample uniformly from those nodes
-        node3 = random.choice(key, descendants, shape=(1,), replace=False)
-        # get node index of node3
-        node3_idx = jnp.where(tree.labels == node3)[0]
-        # attach node i to that node
-        new_adj_mat = new_adj_mat.at[node3_idx, node1_idx].set(1)
-        # make new tree
-        new_tree = Tree(tree_topology=new_adj_mat, labels=tree.labels)
-
-        logger.debug(
-            "MCMC: Swap subtrees move - nested swap of"
-            " subtrees rooted at node %s and node %s",
-            node1,
-            node2,
-        )
-        return new_tree
-
-
-def _swap_subtrees_proposal_backup(
-    key: random.PRNGKeyArray, tree: Tree
-) -> Tuple[Tree, float]:
-    """Samples a new proposal using the "swap subtrees" move.
-    Args:
-        key: JAX random key
-        tree: original tree from which we will build a new sample
-    Returns:
-        new tree
-        float, representing the correction factor
-            :math`\\log q(new tree | old tree) - \\log q(old tree | new tree)`.
-
-    Note: - assumes that the last node, by index, is the root node.
-    """
-    # split key - needed if nodes of same lineage are drawn
-    key_node_choice, key_same_lineage = random.split(key)
-    # Sample two distinct non-root labels
-    node1, node2 = random.choice(
-        key_node_choice, tree.labels[:-1], shape=(2,), replace=False
-    )
-    # are they in the same lineage? - is this a nested subtree move?
-    desc_node1 = get_descendants(tree.tree_topology, tree.labels, node1)
-    desc_node2 = get_descendants(tree.tree_topology, tree.labels, node2)
-    same_lineage = False
-    if node2 in desc_node1 or node1 in desc_node2:
-        same_lineage = True
-        logger.debug("MCMC: Swap subtrees move - nodes of same lineage ")
-        if node1 in desc_node2:
-            # swap, to make node 2 the descendant
-            # node 1 is node i and node 2 is node k
-            node1, node2 = node2, node1
-            logger.debug("MCMC: Swap subtrees move - swapping nodes")
-
-    # new tree
-    # simple case - swap two nodes that are not in the same lineage
-    if not same_lineage:
-        # Note: correction factor is zero as, move as equal proposal probability
-        return _swap_subtrees_move(tree, node1, node2, same_lineage), 0.0
-        # nodes are in same lineage - avoid cycles
-    else:  # node 2 is descendant, i.e. node k
-        # \Delta q = log q(new|old) - log q(old|new) = log [d(i)+1] - log [d(k)+1]
-        # Note: inverse of the way it is represented in the paper's supplement
-        # where k is the descendant node of i
-        corr = float(
-            jnp.log(desc_node1.shape[0] + 1.0) - jnp.log(desc_node2.shape[0] + 1.0)
-        )
-        return (
-            _swap_subtrees_move(tree, node1, node2, same_lineage, key_same_lineage),
-            corr,
-        )
-
-
 def _swap_subtrees_proposal(key: JAXRandomKey, tree: Tree) -> Tuple[Tree, float]:
     """Samples a new proposal using the "swap subtrees" move.
     Args:
@@ -405,9 +280,10 @@ def _swap_subtrees_proposal(key: JAXRandomKey, tree: Tree) -> Tuple[Tree, float]
     # are they in the same lineage? - is this a nested subtree move?
     desc_node1 = get_descendants(tree.tree_topology, tree.labels, node1)
     desc_node2 = get_descendants(tree.tree_topology, tree.labels, node2)
-    same_lineage = False
-    if node2 in desc_node1 or node1 in desc_node2:
-        same_lineage = True
+    # same lineage if node 2 is descendant, i.e. node k or reverse
+    same_lineage = node2 in desc_node1 or node1 in desc_node2
+
+    if same_lineage:
         logger.debug("MCMC: Swap subtrees move - nodes of same lineage ")
         if node1 in desc_node2:
             # swap, to make node 2 the descendant
@@ -415,13 +291,7 @@ def _swap_subtrees_proposal(key: JAXRandomKey, tree: Tree) -> Tuple[Tree, float]
             node1, node2 = node2, node1
             logger.debug("MCMC: Swap subtrees move - swapping nodes")
 
-    # new tree
-    # simple case - swap two nodes that are not in the same lineage
-    if not same_lineage:
-        # Note: correction factor is zero as, move as equal proposal probability
-        return _swap_subtrees_move_diff_lineage(tree, node1, node2), 0.0
-        # nodes are in same lineage - avoid cycles
-    else:  # node 2 is descendant, i.e. node k
+        # new tree
         # \Delta q = log q(new|old) - log q(old|new) = log [d(i)+1] - log [d(k)+1]
         # Note: inverse of the way it is represented in the paper's supplement
         # where k is the descendant node of i
@@ -432,6 +302,10 @@ def _swap_subtrees_proposal(key: JAXRandomKey, tree: Tree) -> Tuple[Tree, float]
             _swap_subtrees_move_same_lineage(tree, node1, node2, key_same_lineage),
             corr,
         )
+    else:
+        # simple case - swap two nodes that are not in the same lineage
+        # Note: correction factor is zero as, move has equal proposal probability
+        return _swap_subtrees_move_diff_lineage(tree, node1, node2), 0.0
 
 
 @dataclasses.dataclass

--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -184,6 +184,8 @@ def _swap_subtrees_proposal(key: random.PRNGKeyArray, tree: Tree) -> Tuple[Tree,
         new tree
         float, representing the correction factor
             :math`\\log q(new tree | old tree) - \\log q(old tree | new tree)`.
+
+    Note: assumes that the last node, by index, is the root node.
     """
     # Sample two distinct non-root labels
     node1, node2 = random.choice(key, tree.labels[:-1], shape=(2,), replace=False)

--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -192,6 +192,10 @@ def _swap_subtrees_proposal(key: random.PRNGKeyArray, tree: Tree) -> Tuple[Tree,
     same_lineage = False
     desc_node1 = tr._get_descendants(tree.tree_topology, tree.labels, node1)
     if node2 in desc_node1:
+        logger.debug(
+            "MCMC: Swap subtrees move - nodes of same lineage "
+            "- swapping descendants first"
+        )
         # swap, to make node 2 the descendant
         node1, node2 = node2, node1
         same_lineage = True

--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -138,7 +138,7 @@ def _swap_node_labels_proposal(
     return _swap_node_labels_move(tree=tree, node1=node1, node2=node2), 0.0
 
 
-def _swap_subtrees_move(tree: Tree, node1: int, node2: int) -> Tree:
+def _swap_subtrees_move(tree: Tree, node1: int, node2: int, same_lineage: bool, key: random.PRNGKeyArray = None) -> Tree:
     """Swaps subtrees rooted at ``node1`` and ``node2``.
 
     Args:
@@ -159,20 +159,42 @@ def _swap_subtrees_move(tree: Tree, node1: int, node2: int) -> Tree:
     new_adj_mat = tree.tree_topology.at[parent1_idx, node1_idx].set(0)
     # detach subtree 2
     new_adj_mat = new_adj_mat.at[parent2_idx, node2_idx].set(0)
-    # attach subtree 1 to parent of node2
-    new_adj_mat = new_adj_mat.at[parent2_idx, node1_idx].set(1)
-    # attach subtree 2 to parent of node1
-    new_adj_mat = new_adj_mat.at[parent1_idx, node2_idx].set(1)
-    # make new tree
-    new_tree = Tree(tree_topology=new_adj_mat, labels=tree.labels)
 
-    logger.debug(
-        "MCMC: Swap subtrees move - swapped subtrees rooted at node %s and node %s",
-        node1,
-        node2,
-    )
+    if not same_lineage:
+        # attach subtree 1 to parent of node2
+        new_adj_mat = new_adj_mat.at[parent2_idx, node1_idx].set(1)
+        # attach subtree 2 to parent of node1
+        new_adj_mat = new_adj_mat.at[parent1_idx, node2_idx].set(1)
+        # make new tree
+        new_tree = Tree(tree_topology=new_adj_mat, labels=tree.labels)
 
-    return new_tree
+        logger.debug(
+            "MCMC: Swap subtrees move - swapped subtrees rooted at node %s and node %s",
+            node1,
+            node2,
+        )
+        return new_tree
+
+    # if same lineage
+    else:
+        # attach subtree of k to parent of i - i.e. attach parent of node i/1 to node k/2
+        new_adj_mat = new_adj_mat.at[parent1_idx, node2_idx].set(1)
+        # get descendants of node k including k itself, as possible nodes attach node i to
+        descendants = tr._get_descendants(tree.tree_topology, tree.labels, node2, include_parent=True)
+        # sample uniformly from those nodes
+        node3 = random.choice(key, descendants, shape=(1,), replace=False)
+        # attach node i to that node
+        new_adj_mat = new_adj_mat.at[node3, node1_idx].set(1)
+        # make new tree
+        new_tree = Tree(tree_topology=new_adj_mat, labels=tree.labels)
+
+        logger.debug(
+            "MCMC: Swap subtrees move - nested swap of subtrees rooted at node %s and node %s",
+            node1,
+            node2,
+        )
+        return new_tree
+
 
 
 def _swap_subtrees_proposal(key: random.PRNGKeyArray, tree: Tree) -> Tuple[Tree, float]:
@@ -185,36 +207,41 @@ def _swap_subtrees_proposal(key: random.PRNGKeyArray, tree: Tree) -> Tuple[Tree,
         float, representing the correction factor
             :math`\\log q(new tree | old tree) - \\log q(old tree | new tree)`.
 
-    Note: assumes that the last node, by index, is the root node.
+    Note: - assumes that the last node, by index, is the root node.
     """
+    # split key - needed if nodes of same lineage are drawn
+    key_node_choice, key_same_lineage = random.split(key)
     # Sample two distinct non-root labels
-    node1, node2 = random.choice(key, tree.labels[:-1], shape=(2,), replace=False)
-    # make sure we swap the descendants first
-    # (in case the nodes are in the same lineage)
-    same_lineage = False
+    node1, node2 = random.choice(key_node_choice, tree.labels[:-1], shape=(2,), replace=False)
+    # are they in the same lineage? - is this a nested subtree move?
     desc_node1 = tr._get_descendants(tree.tree_topology, tree.labels, node1)
-    if node2 in desc_node1:
+    desc_node2 = tr._get_descendants(tree.tree_topology, tree.labels, node2)
+    same_lineage = False
+    if node2 in desc_node1 or node1 in desc_node2:
+        same_lineage = True
         logger.debug(
             "MCMC: Swap subtrees move - nodes of same lineage "
-            "- swapping descendants first"
         )
-        # swap, to make node 2 the descendant
-        node1, node2 = node2, node1
-        same_lineage = True
+        if node1 in desc_node2:
+            # swap, to make node 2 the descendant
+            # node 1 is node i and node 2 is node k
+            node1, node2 = node2, node1
+            logger.debug("MCMC: Swap subtrees move - swapping nodes")
+
     # new tree
     # simple case - swap two nodes that are not in the same lineage
     if not same_lineage:
         # Note: correction factor is zero as, move as equal proposal probability
-        return _swap_subtrees_move(tree, node1, node2), 0.0
+        return _swap_subtrees_move(tree, node1, node2, same_lineage), 0.0
         # nodes are in same lineage - avoid cycles
-    else:  # node 2 is descendant
-        desc_node2 = tr._get_descendants(tree.tree_topology, tree.labels, node2)
+    else:  # node 2 is descendant, i.e. node k
         # \Delta q = log q(new|old) - log q(old|new) = log [d(i)+1] - log [d(k)+1]
+        # Note: inverse of the way it is represented in the paper's supplement
         # where k is the descendant node of i
         corr = float(
             jnp.log(desc_node1.shape[0] + 1.0) - jnp.log(desc_node2.shape[0] + 1.0)
         )
-        return _swap_subtrees_move(tree, node1, node2), corr
+        return _swap_subtrees_move(tree, node1, node2, same_lineage, key_same_lineage), corr
 
 
 @dataclasses.dataclass

--- a/src/pyggdrasil/tree_inference/_mcmc_sampler.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_sampler.py
@@ -28,6 +28,9 @@ from pyggdrasil.tree_inference._interface import (
     ErrorRates,
 )
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
 
 def mcmc_sampler(
     rng_key: JAXRandomKey,
@@ -62,7 +65,7 @@ def mcmc_sampler(
         None
     """
 
-    logging.info("Starting MCMC sampler.")
+    logger.info("Starting MCMC sampler.")
 
     # TODO: implement support for NAs and homozygous mutations
     # check data i.e. mutation matrix
@@ -87,7 +90,7 @@ def mcmc_sampler(
         logprobability_fn(init_tree),
     )
 
-    logging.info("Starting MCMC loop.")
+    logger.info("Starting MCMC loop.")
 
     # define loop body
     def body(
@@ -173,4 +176,4 @@ def mcmc_sampler(
 
     while_loop(cond_fn, body, init_state)
 
-    logging.info("Finished MCMC sampler.")
+    logger.info("Finished MCMC sampler.")

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -84,6 +84,8 @@ def _prune_and_reattach_subtree(
 
     Only for visualization/testing purposes.
 
+    Is not designed for same-lineage reattachment - to be teste.
+
     Returns:
         new tree, with node ``pruned_node`` pruned and reattached to ``attach_to``.
 

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -28,7 +28,7 @@ def _prune(tree: Tree, pruned_node: int) -> tuple[Tree, Tree]:
         tuple of [remaining tree, subtree]
     """
     # get subtree labels
-    subtree_labels = tr._get_descendants(
+    subtree_labels = tr.get_descendants(
         tree.tree_topology, tree.labels, pruned_node, include_parent=True
     )
     # get subtree indices - assumes labels of tree and subtree are in the sane order

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -30,7 +30,7 @@ def _prune(tree: Tree, pruned_node: int) -> tuple[Tree, Tree]:
     """
     # get subtree labels
     subtree_labels = tr._get_descendants(
-        tree.tree_topology, tree.labels, pruned_node, includeParent=True
+        tree.tree_topology, tree.labels, pruned_node, include_parent=True
     )
     # get subtree indices - assumes labels of tree and subtree are in the sane order
     subtree_idx = jnp.where(jnp.isin(tree.labels, subtree_labels))[0].tolist()

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -10,7 +10,6 @@ import pyggdrasil.tree_inference._tree as tr
 from pyggdrasil.interface import MCMCSample
 
 
-# TODO: consider moving all these 3 function to tests only
 def _prune(tree: Tree, pruned_node: int) -> tuple[Tree, Tree]:
     """Prune subtree, by cutting edge leading to node parent
     to obtain subtree of descendants desc and the remaining tree.
@@ -78,10 +77,12 @@ def _reattach(tree: Tree, subtree: Tree, attach_to: int, pruned_node: int) -> Tr
     return Tree(new_tree_adj, jnp.append(tree.labels, subtree.labels))
 
 
-def _prune_and_reattach_move(tree: Tree, *, pruned_node: int, attach_to: int) -> Tree:
+def _prune_and_reattach_subtree(
+    tree: Tree, *, pruned_node: int, attach_to: int
+) -> Tree:
     """Prune a node from tree topology and attach it to another one.
 
-    LEGACY CODE - Only for visualization/testing purposes
+    Only for visualization/testing purposes.
 
     Returns:
         new tree, with node ``pruned_node`` pruned and reattached to ``attach_to``.

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -390,7 +390,7 @@ def shortest_path_to_ancestry_matrix(sp_matrix: np.ndarray) -> interface.Ancesto
     return ancestor_mat
 
 
-def get_descendants(
+def get_descendants_fw(
     adj_matrix: adjacency_matrix,
     node: int,
 ) -> np.ndarray:

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -14,6 +14,9 @@ import logging
 from pyggdrasil.tree import TreeNode
 import pyggdrasil.tree_inference as tree_inf
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
 
 @dataclasses.dataclass(frozen=True)
 class Tree:
@@ -209,7 +212,11 @@ def _get_root_label(tree: Tree) -> int:
     # find row which has all ones in ancestor_matrix
     root_idx = jnp.where(jnp.all(ancestor_matrix == 1, axis=1))[0]
     if len(root_idx) > 1:
+        logger.error("More than one root found - not a tree")
         raise ValueError("More than one root found - not a tree")
+    elif len(root_idx) == 0:
+        logger.error("No root found - not a tree")
+        raise ValueError("No root found - not a tree")
     # get root label
     root_label = int(tree.labels[root_idx])
 

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -107,7 +107,7 @@ def _resort_root_to_end(tree: Tree, root: int) -> Tree:
 
 
 def _get_descendants(
-    adj_matrix: Array, labels: Array, parent: int, includeParent: bool = False
+    adj_matrix: Array, labels: Array, parent: int, include_parent: bool = False
 ) -> Array:
     """
     Returns a list of labels representing the descendants of node parent.
@@ -140,7 +140,7 @@ def _get_descendants(
     # get labels correspond to indices
     desc_labels = labels[desc]
     # remove parent - as self-looped
-    if not includeParent:
+    if not include_parent:
         desc_labels = desc_labels[desc_labels != parent]
     return desc_labels
 

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -106,7 +106,7 @@ def _resort_root_to_end(tree: Tree, root: int) -> Tree:
     return resorted_tree
 
 
-def _get_descendants(
+def get_descendants(
     adj_matrix: Array, labels: Array, parent: int, include_parent: bool = False
 ) -> Array:
     """

--- a/src/pyggdrasil/visualize/__init__.py
+++ b/src/pyggdrasil/visualize/__init__.py
@@ -1,1 +1,5 @@
 """Visualization methods for trees, tree distances and likelihoods."""
+
+from pyggdrasil.visualize.tree import plot
+
+__all__ = ["plot"]

--- a/src/pyggdrasil/visualize/tree.py
+++ b/src/pyggdrasil/visualize/tree.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from networkx.drawing.nx_pydot import graphviz_layout
 import networkx as nx
 import logging
-from typing import Union
+from typing import Union, Optional
 
 from pyggdrasil import TreeNode
 
@@ -23,7 +23,7 @@ def plot(
     save_name: str,
     save_dir: Path,
     print_options: dict,
-    rename_labels: dict[str, NodeLabel],
+    rename_labels: Optional[dict[str, NodeLabel]] = None,
 ) -> None:
     """Plot a tree and save it to a file.
 

--- a/src/pyggdrasil/visualize/tree.py
+++ b/src/pyggdrasil/visualize/tree.py
@@ -81,8 +81,22 @@ def plot(
     # convert to networkX graph
     nx_graph = nx.nx_pydot.from_pydot(graph)
 
+    # dynamically set figsize
+    # Calculate the depth and width of the tree
+    depth = nx.dag_longest_path_length(nx_graph)
+    width = max(len(list(nx.descendants(nx_graph, node))) for node in nx_graph.nodes())
+
+    # Calculate an appropriate figure size
+    node_width = 0.5  # Width of each node in the figure
+    node_height = 0.75  # Height of each node in the figure
+    figure_width = width * node_width
+    figure_height = depth * node_height
+
+    # print(f"figure_width: {figure_width}")
+    # print(f"figure_height: {figure_height}")
+
     # plot
-    fig = plt.figure()
+    fig = plt.figure(figsize=(figure_width, figure_height))
 
     # LaTeX preamble
     latex_preamble = r"""

--- a/src/pyggdrasil/visualize/tree.py
+++ b/src/pyggdrasil/visualize/tree.py
@@ -14,6 +14,10 @@ from typing import Union, Optional
 
 from pyggdrasil import TreeNode
 
+# setup logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
 
 NodeLabel = Union[str, int, float]
 
@@ -55,6 +59,12 @@ def plot(
     Note:
         see tests/visualize/test_tree.py for example usage
     """
+
+    # check if tree-name is none and throw log - and error
+    if tree.name is None and print_options["title"] is True:
+        logger.error("Tree name is None, cannot print title")
+        raise ValueError("Tree name is None, cannot print title")
+
     # make full path
     fullpath = os.path.join(save_dir, save_name)
     # make output directory if it doesn't exist
@@ -115,7 +125,6 @@ def plot(
     node_sizes = np.array([])
     for element in nx_graph.nodes:
         node_sizes = np.append(node_sizes, len(str(element)) * 520)
-    print(node_sizes)
 
     # plot graph
     nx.draw(
@@ -148,3 +157,4 @@ def plot(
 
     plt.savefig(fullpath + ".svg", bbox_inches="tight")
     plt.close()
+    logger.info(f"Saved tree plot to {fullpath}.svg")

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -77,7 +77,9 @@ def test_prune_and_reattach_move():
 
 def test_prune_and_reattach_moves():
     """Test mcmc.prune_and_reattach_moves. against
-    mcmc_util.prune_and_reattach_move. - manual test"""
+    mcmc_util.prune_and_reattach_move. - manual test
+
+    Note only different lineage moves are to be tested with the mcmc util function."""
     # Original tree
     tree_adj = jnp.array(
         [
@@ -96,7 +98,7 @@ def test_prune_and_reattach_moves():
     new_tree_1 = mcmc._prune_and_reattach_move(tree, pruned_node=2, attach_to=3)
 
     # new tree
-    new_tree_2 = mcmc_util._prune_and_reattach_move(tree, pruned_node=2, attach_to=3)
+    new_tree_2 = mcmc_util._prune_and_reattach_subtree(tree, pruned_node=2, attach_to=3)
     new_tree_2_resort = tr._reorder_tree(
         new_tree_2, new_tree_2.labels, new_tree_1.labels
     )
@@ -140,7 +142,7 @@ def test_prune_and_reattach_moves_auto(seed: int, n_nodes: int):
     print(new_tree_1.tree_topology)
     new_tree_1.print_topo()
     # new tree
-    new_tree_2 = mcmc_util._prune_and_reattach_move(
+    new_tree_2 = mcmc_util._prune_and_reattach_subtree(
         tree, pruned_node=pruned_node, attach_to=attach_to
     )
     new_tree_2_resort = tr._reorder_tree(

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -238,3 +238,107 @@ def test_swap_subtrees_move_fig16_diff_lineage():
 
     assert jnp.array_equal(new_tree.tree_topology, new_tree_corr.tree_topology)
     assert jnp.array_equal(new_tree.labels, new_tree_corr.labels)
+
+
+def test_swap_subtrees_move_fig17_nested_subtrees():
+    """Test mcmc.swap_subtrees_move  - manual test
+    equal to the simple case in fig 17 of the paper,
+    where two nodes are not of the same lineage."""
+
+    # Original tree
+    tree_adj = jnp.array(
+        [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+            [0, 1, 0, 1, 0, 0, 1, 0, 0],  # 1
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 2
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 4
+            [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 7
+            [1, 0, 0, 0, 0, 0, 0, 0, 0],  # 8
+            [0, 0, 1, 0, 1, 0, 0, 1, 0],  # R
+        ]
+    )
+    labels = jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    tree = Tree(tree_adj, labels)
+
+    # new tree
+    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1)
+
+    # if the i node was attached to node k itself, by uniform sampling
+    new_tree_corr1 = Tree(
+        jnp.array(
+            [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+                [0, 1, 0, 1, 0, 0, 1, 1, 0],  # 1
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 2
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 4
+                [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 7
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 8
+                [1, 0, 1, 0, 1, 0, 0, 0, 0],  # R
+            ]
+        ),
+        labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    )
+    # if the i node was attached node 2
+    new_tree_corr2 = Tree(
+        jnp.array(
+            [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+                [0, 1, 0, 1, 0, 0, 1, 0, 0],  # 1
+                [0, 0, 0, 0, 0, 0, 0, 1, 0],  # 2
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 4
+                [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 7
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 8
+                [1, 0, 1, 0, 1, 0, 0, 0, 0],  # R
+            ]
+        ),
+        labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    )
+    # if the i node was attached node 4
+    new_tree_corr3 = Tree(
+        jnp.array(
+            [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+                [0, 1, 0, 1, 0, 0, 1, 0, 0],  # 1
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 2
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+                [0, 0, 0, 0, 0, 0, 0, 1, 0],  # 4
+                [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 7
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 8
+                [1, 0, 1, 0, 1, 0, 0, 0, 0],  # R
+            ]
+        ),
+        labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    )
+    # if the i node was attached node 7
+    new_tree_corr4 = Tree(
+        jnp.array(
+            [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+                [0, 1, 0, 1, 0, 0, 1, 0, 0],  # 1
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 2
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 4
+                [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+                [0, 0, 0, 0, 0, 0, 0, 1, 0],  # 7
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 8
+                [1, 0, 1, 0, 1, 0, 0, 0, 0],  # R
+            ]
+        ),
+        labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    )
+    # check if any of the four possible trees is the same as the new tree
+    assert (
+        jnp.array_equal(new_tree.tree_topology, new_tree_corr1.tree_topology)
+        or jnp.array_equal(new_tree.tree_topology, new_tree_corr2.tree_topology)
+        or jnp.array_equal(new_tree.tree_topology, new_tree_corr3.tree_topology)
+        or jnp.array_equal(new_tree.tree_topology, new_tree_corr4.tree_topology)
+    )
+    # check if the labels are the same, just once for sanity
+    assert jnp.array_equal(new_tree.labels, new_tree_corr1.labels)

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -24,7 +24,7 @@ def test_swap_node_labels_move(seed: int):
     # generate random nodes - NB: root may not be swapped, hence n_nodes-1
     node1, node2 = random.randint(rng_nodes, shape=(2,), minval=0, maxval=n_nodes - 1)
     # assign labels
-    tree01 = mcmc.Tree(adj_mat, jnp.arange(n_nodes))
+    tree01 = mcmc.Tree(jnp.array(adj_mat), jnp.arange(n_nodes))
     # swap labels
     tree01_labels = tree01.labels
     tree02 = mcmc._swap_node_labels_move(tree01, node1, node2)
@@ -187,6 +187,53 @@ def test_swap_subtrees_move():
             ]
         ),
         jnp.array([8, 7, 6, 5, 4, 3, 2, 1]),
+    )
+
+    assert jnp.array_equal(new_tree.tree_topology, new_tree_corr.tree_topology)
+    assert jnp.array_equal(new_tree.labels, new_tree_corr.labels)
+
+
+def test_swap_subtrees_move_fig16_diff_lineage():
+    """Test mcmc.swap_subtrees_move  - manual test
+    equal to the simple case in fig 16 of the paper,
+    where two nodes are not of the same lineage,
+    are not parent-child relationship."""
+
+    # Original tree
+    tree_adj = jnp.array(
+        [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+            [0, 1, 0, 1, 0, 0, 1, 0, 0],  # 1
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 2
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 4
+            [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 7
+            [1, 0, 0, 0, 0, 0, 0, 0, 0],  # 8
+            [0, 0, 1, 0, 1, 0, 0, 1, 0],  # R
+        ]
+    )
+    labels = jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    tree = Tree(tree_adj, labels)
+
+    # new tree
+    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1)
+
+    new_tree_corr = Tree(
+        jnp.array(
+            [  # 1, 2, 3, 4, 5, 6, 7, 8, R
+                [0, 1, 0, 1, 0, 0, 1, 0, 0],  # 1
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 2
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 3
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 4
+                [0, 0, 0, 0, 0, 1, 0, 0, 0],  # 5
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 6
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],  # 7
+                [0, 0, 0, 0, 1, 0, 0, 0, 0],  # 8
+                [1, 0, 1, 0, 0, 0, 0, 1, 0],  # R
+            ]
+        ),
+        labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
     )
 
     assert jnp.array_equal(new_tree.tree_topology, new_tree_corr.tree_topology)

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -337,6 +337,9 @@ def test_swap_subtrees_move_fig17_nested_subtrees(seed):
         ),
         labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
     )
+
+    print(new_tree.tree_topology)
+
     # check if any of the four possible trees is the same as the new tree
     assert (
         jnp.array_equal(new_tree.tree_topology, new_tree_corr1.tree_topology)

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -131,7 +131,7 @@ def test_prune_and_reattach_moves_auto(seed: int, n_nodes: int):
         # choose a node to attach to - including root
         attach_to = int(random.randint(rng_attach, (), minval=0, maxval=n_nodes))
         # check that attach_to node is not a descendant of pruned_node
-        desc = tr._get_descendants(tree_adj, labels, pruned_node, include_parent=True)
+        desc = tr.get_descendants(tree_adj, labels, pruned_node, include_parent=True)
         if attach_to not in desc:
             node_pair_found = True
 

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -173,7 +173,7 @@ def test_swap_subtrees_move():
     tree = Tree(tree_adj, labels)
 
     # new tree
-    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=3, same_lineage=False)
+    new_tree = mcmc._swap_subtrees_move_diff_lineage(tree, node1=5, node2=3)
 
     new_tree_corr = Tree(
         jnp.array(
@@ -219,7 +219,7 @@ def test_swap_subtrees_move_fig16_diff_lineage():
     tree = Tree(tree_adj, labels)
 
     # new tree
-    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1, same_lineage=False)
+    new_tree = mcmc._swap_subtrees_move_diff_lineage(tree, node1=5, node2=1)
 
     new_tree_corr = Tree(
         jnp.array(
@@ -269,9 +269,7 @@ def test_swap_subtrees_move_fig17_nested_subtrees(seed):
     key = random.PRNGKey(seed)
 
     # new tree
-    new_tree = mcmc._swap_subtrees_move(
-        tree, node1=8, node2=1, same_lineage=True, key=key
-    )
+    new_tree = mcmc._swap_subtrees_move_same_lineage(tree, node1=8, node2=1, key=key)
 
     # if the i node was attached to node k itself, by uniform sampling
     new_tree_corr1 = Tree(

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -129,7 +129,7 @@ def test_prune_and_reattach_moves_auto(seed: int, n_nodes: int):
         # choose a node to attach to - including root
         attach_to = int(random.randint(rng_attach, (), minval=0, maxval=n_nodes))
         # check that attach_to node is not a descendant of pruned_node
-        desc = tr._get_descendants(tree_adj, labels, pruned_node, includeParent=True)
+        desc = tr._get_descendants(tree_adj, labels, pruned_node, include_parent=True)
         if attach_to not in desc:
             node_pair_found = True
 
@@ -171,7 +171,7 @@ def test_swap_subtrees_move():
     tree = Tree(tree_adj, labels)
 
     # new tree
-    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=3)
+    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=3, same_lineage=False)
 
     new_tree_corr = Tree(
         jnp.array(
@@ -217,7 +217,7 @@ def test_swap_subtrees_move_fig16_diff_lineage():
     tree = Tree(tree_adj, labels)
 
     # new tree
-    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1)
+    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1, same_lineage=False)
 
     new_tree_corr = Tree(
         jnp.array(
@@ -240,7 +240,8 @@ def test_swap_subtrees_move_fig16_diff_lineage():
     assert jnp.array_equal(new_tree.labels, new_tree_corr.labels)
 
 
-def test_swap_subtrees_move_fig17_nested_subtrees():
+@pytest.mark.parametrize("seed", [2, 42, 69])
+def test_swap_subtrees_move_fig17_nested_subtrees(seed):
     """Test mcmc.swap_subtrees_move  - manual test
     equal to the simple case in fig 17 of the paper,
     where two nodes are not of the same lineage."""
@@ -262,8 +263,11 @@ def test_swap_subtrees_move_fig17_nested_subtrees():
     labels = jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     tree = Tree(tree_adj, labels)
 
+    # make jax random key
+    key = random.PRNGKey(seed)
+
     # new tree
-    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1)
+    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1, same_lineage=True, key=key)
 
     # if the i node was attached to node k itself, by uniform sampling
     new_tree_corr1 = Tree(

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -267,7 +267,9 @@ def test_swap_subtrees_move_fig17_nested_subtrees(seed):
     key = random.PRNGKey(seed)
 
     # new tree
-    new_tree = mcmc._swap_subtrees_move(tree, node1=5, node2=1, same_lineage=True, key=key)
+    new_tree = mcmc._swap_subtrees_move(
+        tree, node1=8, node2=1, same_lineage=True, key=key
+    )
 
     # if the i node was attached to node k itself, by uniform sampling
     new_tree_corr1 = Tree(
@@ -337,8 +339,6 @@ def test_swap_subtrees_move_fig17_nested_subtrees(seed):
         ),
         labels=jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
     )
-
-    print(new_tree.tree_topology)
 
     # check if any of the four possible trees is the same as the new tree
     assert (

--- a/tests/tree_inference/test_mcmc_util.py
+++ b/tests/tree_inference/test_mcmc_util.py
@@ -106,7 +106,7 @@ def test_prune_and_reattach_move():
     tree = Tree(tree_adj, labels)
 
     # new tree
-    new_tree = mcmc_util._prune_and_reattach_move(tree, pruned_node=2, attach_to=3)
+    new_tree = mcmc_util._prune_and_reattach_subtree(tree, pruned_node=2, attach_to=3)
 
     new_tree_corr = Tree(
         jnp.array(

--- a/tests/tree_inference/test_tree.py
+++ b/tests/tree_inference/test_tree.py
@@ -31,14 +31,14 @@ def test_get_descendants(seed: int, n_nodes: int):
     # make tree
     tree = Tree(adj_mat, labels)  # TODO: make labels random
     # get descendants with matrix exponentiation
-    desc01 = tr._get_descendants(
+    desc01 = tr.get_descendants(
         jnp.array(tree.tree_topology), jnp.array(tree.labels), parent
     )
     # get descendants with Floyd-Warshall
     adj_mat_prime = np.array(tree.tree_topology)
     np.fill_diagonal(adj_mat_prime, 1)
     parent_idx = np.where(tree.labels == parent)[0][0]
-    desc02_idx = np.where(tree_inf.get_descendants(adj_mat_prime, parent_idx) == 1)
+    desc02_idx = np.where(tree_inf.get_descendants_fw(adj_mat_prime, parent_idx) == 1)
     desc02 = tree.labels[desc02_idx]
     desc02 = desc02[desc02 != parent]
 

--- a/tests/visualize/test_viz_tree.py
+++ b/tests/visualize/test_viz_tree.py
@@ -8,7 +8,7 @@ import pytest
 # needed to inspect output at data/trees
 # from pathlib import Path
 
-from pyggdrasil.tree_inference._tree import Tree
+from pyggdrasil.tree_inference import Tree
 import pyggdrasil.visualize as viz
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"

--- a/tests/visualize/test_viz_tree.py
+++ b/tests/visualize/test_viz_tree.py
@@ -9,7 +9,7 @@ import pytest
 # from pathlib import Path
 
 from pyggdrasil.tree_inference._tree import Tree
-import pyggdrasil.visualize.tree as viz
+import pyggdrasil.visualize as viz
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 


### PR DESCRIPTION
This PR addresses/closes #48 mainly, it also closes #47. 

The `tree_inference.mcmc._swap_subtrees_move` and `tree_inference.mcmc._swap_subtrees_proposal` were incomplete/wrong for the case of choosing nodes of the same lineage. Now fixed and tested against the SCITE supplement paper examples. 

The failure of this tree move became apparent during the coding of the _Visualization of the Timeseries_ in #42, as some trees were broken into two and mcmc samples could not be imported.

To convince myself the tree moves now make sense and the trees don't break, I decided to include a small visualization script of the trees of a mcmc chain in this PR. This resulted in a very satisfying animation. See here: 

![animation](https://github.com/cbg-ethz/PYggdrasil/assets/10867778/cd4a0909-2da1-4b2f-be36-e5f7c867473f)

These are the main objectives of this PR. 

It took a bit of tracing of the issues, hence note the addition of `loggers` in many scripts. 

Merging this PR will allow us to proceed with the  _Visualization of the Timeseries_ in #42.

Apologies for the large and messy PR - the result of some digging for the bug and the self-convincing of its workings.

