### PR TITLE
Creating modular ID classes for (Trees, Cell Simulations, MCMC Run) for file naming

### DIFF
--- a/scripts/run_mcmc.py
+++ b/scripts/run_mcmc.py
@@ -51,7 +51,7 @@ import pytz
 
 from pathlib import Path
 from datetime import datetime, timedelta
-from typing import Optional, TypedDict
+from typing import Optional
 
 import pyggdrasil.tree_inference as tree_inf
 import pyggdrasil.serialize as serialize
@@ -59,27 +59,9 @@ import pyggdrasil.serialize as serialize
 from pyggdrasil.tree_inference import (
     MutationMatrix,
     mcmc_sampler,
-    MoveProbabilities,  # type: ignore
+    MoveProbabilities,
+    McmcConfig,
 )
-
-
-class MoveProbConfig(TypedDict):
-    """Move probabilities for MCMC sampler."""
-
-    prune_and_reattach: float
-    swap_node_labels: float
-    swap_subtrees: float
-
-
-class McmcConfig(TypedDict):
-    """Config for MCMC sampler."""
-
-    move_probs: MoveProbConfig
-    fpr: float
-    fnr: float
-    num_samples: int
-    burn_in: int
-    thinning: int
 
 
 def create_parser() -> argparse.Namespace:

--- a/src/pyggdrasil/interface/__init__.py
+++ b/src/pyggdrasil/interface/__init__.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 
 from pyggdrasil import TreeNode
 
-
 # MCMC sample in xarray format.
 # example:
 # <xarray.Dataset>

--- a/src/pyggdrasil/interface/_file_naming.py
+++ b/src/pyggdrasil/interface/_file_naming.py
@@ -1,0 +1,159 @@
+"""Provides classes for naming files Tree,
+Cell Simulation and MCMC run files uniquely """
+
+from enum import Enum
+from typing import Union
+
+from pyggdrasil.tree_inference import CellAttachmentStrategy, McmcConfig
+
+
+class TreeType(Enum):
+    """Enum representing valid tree types implemented in pyggdrasil.
+
+    Allowed values:
+      - RANDOM (random tree)
+      - STAR (star tree)
+      - DEEP (deep tree)
+      - HUNTRESS (Huntress tree) - inferred from real / cell simulation data
+    """
+
+    RANDOM = "R"
+    STAR = "S"
+    DEEP = "D"
+    HUNTRESS = "H"
+
+
+class MutationDataId:
+    """Class representing a mutation data id.
+
+    In case we want to infer a tree from real data,
+    we need to provide a mutation data id.
+    """
+
+    id: str
+
+    raise NotImplementedError
+
+
+class CellSimulationId:
+    """Class representing a cell simulation id."""
+
+    seed: int
+    tree_id: str
+    n_cells: int
+    n_mutations: int
+    fpr: float
+    fnr: float
+    na_rate: float
+    observe_homozygous: bool
+    strategy: CellAttachmentStrategy
+
+    id: str
+
+    def __init__(
+        self,
+        seed: int,
+        tree_id: str,
+        n_cells: int,
+        n_mutations: int,
+        fpr: float,
+        fnr: float,
+        na_rate: float,
+        observe_homozygous: bool,
+        strategy: CellAttachmentStrategy,
+    ):
+        self.seed = seed
+        self.tree_id = tree_id
+        self.n_cells = n_cells
+        self.n_mutations = n_mutations
+        self.fpr = fpr
+        self.fnr = fnr
+        self.na_rate = na_rate
+        self.observe_homozygous = observe_homozygous
+        self.strategy = strategy
+
+        self.id = self._create_id()
+
+    def _create_id(self) -> str:
+        pass
+
+
+class TreeId:
+    """Class representing a tree id.
+
+    A tree id is a unique identifier for a tree.
+
+    tree_type: TreeType - type of tree
+    n_nodes: int - number of nodes in the tree
+    seed: int - seed used to generate the tree
+    cell_simulation_id: str - id of the cell simulation used to generate the tree
+    """
+
+    tree_type: TreeType
+    n_nodes: int
+    seed: int
+    cell_simulation_id: CellSimulationId
+
+    id: str
+
+    def __init__(
+        self,
+        tree_type: TreeType,
+        n_nodes: int,
+        seed: int = None,
+        cell_simulation_id: CellSimulationId = None,
+    ):
+        """Initializes a tree id.
+
+        Args:
+            tree_type: TreeType
+            n_nodes: int
+            seed: int
+        """
+
+        self.tree_type = tree_type
+        self.n_nodes = n_nodes
+        self.seed = seed
+        self.cell_simulation_id = cell_simulation_id
+
+        self.id = self._create_id()
+
+    def _create_id(self) -> str:
+        pass
+
+
+class McmcRunId:
+    """Class representing an MCMC run id."""
+
+    seed: int
+    data: Union[CellSimulationId, MutationDataId]
+    init_tree_id: TreeId
+    mcmc_config_id: McmcConfig
+
+    id: str
+
+    def __init__(
+        self,
+        seed: int,
+        data: Union[CellSimulationId, MutationDataId],
+        init_tree_id: TreeId,
+        mcmc_config_id: McmcConfig,
+    ):
+        """Initializes an MCMC run id.
+
+        Args:
+            seed: int
+            data: Union[CellSimulationId, MutationDataId]
+            init_tree_id: TreeId
+            mcmc_config_id: McmcConfig
+        """
+
+        self.seed = seed
+        self.data = data
+        self.init_tree_id = init_tree_id
+        self.mcmc_config_id = mcmc_config_id
+
+        self.id = self._create_id()
+
+    def _create_id(self) -> str:
+        pass

--- a/src/pyggdrasil/interface/_file_naming.py
+++ b/src/pyggdrasil/interface/_file_naming.py
@@ -17,10 +17,10 @@ class TreeType(Enum):
       - HUNTRESS (Huntress tree) - inferred from real / cell simulation data
     """
 
-    RANDOM = "R"
-    STAR = "S"
-    DEEP = "D"
-    HUNTRESS = "H"
+    RANDOM = "r"
+    STAR = "s"
+    DEEP = "d"
+    HUNTRESS = "h"
 
 
 class MutationDataId:
@@ -62,6 +62,7 @@ class CellSimulationId:
         observe_homozygous: bool,
         strategy: CellAttachmentStrategy,
     ):
+        """Initializes a cell simulation id."""
         self.seed = seed
         self.tree_id = tree_id
         self.n_cells = n_cells
@@ -75,7 +76,27 @@ class CellSimulationId:
         self.id = self._create_id()
 
     def _create_id(self) -> str:
-        pass
+        """Creates a unique id for the cell simulation,
+        by concatenating the values of the attributes"""
+
+        id.self = "CS_" + str(self.seed)
+        id.self = id.self + "_" + str(self.tree_id)
+        id.self = id.self + "_" + str(self.n_cells)
+        id.self = id.self + "_" + str(self.n_mutations)
+        id.self = id.self + "_" + str(self.fpr)
+        id.self = id.self + "_" + str(self.fnr)
+        id.self = id.self + "_" + str(self.na_rate)
+        id.self = id.self + "_" + str(self.observe_homozygous).upper()[0]
+
+        if self.strategy is not CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT:
+            id.self = id.self + "_" + "UXR"
+        elif self.strategy is not CellAttachmentStrategy.UNIFORM_INCLUDE_ROOT:
+            id.self = id.self + "_" + "UIR"
+
+        return id.self
+
+    def __str__(self) -> str:
+        return self.id
 
 
 class TreeId:
@@ -119,7 +140,23 @@ class TreeId:
         self.id = self._create_id()
 
     def _create_id(self) -> str:
-        pass
+        """Creates a unique id for the tree,
+        by concatenating the values of the attributes"""
+
+        id.self = "T"
+        id.self = id.self + "_" + str(self.tree_type.value)
+        id.self = id.self + "_" + str(self.n_nodes)
+
+        if self.seed is not None:
+            id.self = id.self + "_" + str(self.seed)
+
+        if self.cell_simulation_id is not None:
+            id.self = id.self + "_" + str(self.cell_simulation_id)
+
+        return id.self
+
+    def __str__(self) -> str:
+        return self.id
 
 
 class McmcRunId:
@@ -137,7 +174,7 @@ class McmcRunId:
         seed: int,
         data: Union[CellSimulationId, MutationDataId],
         init_tree_id: TreeId,
-        mcmc_config_id: McmcConfig,
+        mcmc_config: McmcConfig,
     ):
         """Initializes an MCMC run id.
 
@@ -145,15 +182,27 @@ class McmcRunId:
             seed: int
             data: Union[CellSimulationId, MutationDataId]
             init_tree_id: TreeId
-            mcmc_config_id: McmcConfig
+            mcmc_config: McmcConfig
         """
 
         self.seed = seed
         self.data = data
         self.init_tree_id = init_tree_id
-        self.mcmc_config_id = mcmc_config_id
+        self.mcmc_config = mcmc_config
 
         self.id = self._create_id()
 
     def _create_id(self) -> str:
-        pass
+        """Creates a unique id for the MCMC run,
+        by concatenating the values of the attributes"""
+
+        id.self = "MCMC"
+        id.self = id.self + "_" + str(self.seed)
+        id.self = id.self + "_" + str(self.data)
+        id.self = id.self + "_" + str(self.init_tree_id)
+        id.self = id.self + "_" + str(self.mcmc_config.id())
+
+        return id.self
+
+    def __str__(self) -> str:
+        return self.id

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -29,7 +29,11 @@ from pyggdrasil.tree_inference._simulate import (
 
 from pyggdrasil.tree_inference._tree import Tree, tree_from_tree_node, get_descendants
 
-from pyggdrasil.tree_inference._mcmc_util import unpack_sample
+from pyggdrasil.tree_inference._mcmc_util import (
+    unpack_sample,
+    MoveProbConfig,
+    McmcConfig,
+)
 
 from pyggdrasil.tree_inference._huntress import huntress_tree_inference
 
@@ -67,4 +71,6 @@ __all__ = [
     "generate_star_tree",
     "AncestorMatrix",
     "CellAttachmentVector",
+    "MoveProbConfig",
+    "McmcConfig",
 ]

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -1,5 +1,7 @@
 """Mutation tree inference from scDNA matrices."""
 
+from pyggdrasil.tree_inference._config import McmcConfig, MoveProbConfig
+
 from pyggdrasil.tree_inference._interface import (
     MutationMatrix,
     JAXRandomKey,
@@ -27,12 +29,18 @@ from pyggdrasil.tree_inference._simulate import (
     CellSimulationModel,
 )
 
+from pyggdrasil.tree_inference._file_id import (
+    TreeType,
+    MutationDataId,
+    TreeId,
+    CellSimulationId,
+    McmcRunId,
+)
+
 from pyggdrasil.tree_inference._tree import Tree, tree_from_tree_node, get_descendants
 
 from pyggdrasil.tree_inference._mcmc_util import (
     unpack_sample,
-    MoveProbConfig,
-    McmcConfig,
 )
 
 from pyggdrasil.tree_inference._huntress import huntress_tree_inference
@@ -71,6 +79,11 @@ __all__ = [
     "generate_star_tree",
     "AncestorMatrix",
     "CellAttachmentVector",
-    "MoveProbConfig",
     "McmcConfig",
+    "MoveProbConfig",
+    "TreeType",
+    "MutationDataId",
+    "TreeId",
+    "CellSimulationId",
+    "McmcRunId",
 ]

--- a/src/pyggdrasil/tree_inference/_config.py
+++ b/src/pyggdrasil/tree_inference/_config.py
@@ -1,0 +1,63 @@
+"""Config classes for MCMC sampler,
+ cell simulation and tree inference, distance calculation."""
+
+from pydantic import BaseModel, validator
+
+
+class MoveProbConfig(BaseModel):
+    """Move probabilities for MCMC sampler."""
+
+    prune_and_reattach: float = 0.1
+    swap_node_labels: float = 0.65
+    swap_subtrees: float = 0.25
+
+    @validator("prune_and_reattach", "swap_node_labels", "swap_subtrees")
+    def move_prob_validator(cls, v):
+        """Probabilities sum to 1."""
+        total = sum(v.values())
+        if total != 1:
+            raise ValueError("Move probabilities must sum to 1")
+        return v
+
+    def id(self) -> str:
+        """String representation of move probabilities."""
+        str_rep = "MPC_" + str(self.prune_and_reattach)
+        str_rep = str_rep + "_" + str(self.swap_node_labels)
+        str_rep = str_rep + "_" + str(self.swap_subtrees)
+        return str_rep
+
+
+class McmcConfig(BaseModel):
+    """Config for MCMC sampler."""
+
+    move_probs: MoveProbConfig
+    fpr: float = 1.24e-06
+    fnr: float = 0.097
+    n_samples: int
+    burn_in: int = 0
+    thinning: int = 1
+
+    @validator("fpr")
+    def fpr_validator(cls, v):
+        """Validate move probabilities."""
+        if v <= 0 or v > 1:
+            raise ValueError("fpr must be between 0 and 1")
+        return v
+
+    @validator("fnr")
+    def fnr_validator(cls, v):
+        """Validate move probabilities."""
+        if v <= 0 or v > 1:
+            raise ValueError("fnr must be between 0 and 1")
+        return v
+
+    def id(self) -> str:
+        """String representation of MCMC config."""
+        str_rep = "MC"
+        str_rep = str_rep + "_" + str(self.fpr)
+        str_rep = str_rep + "_" + str(self.fnr)
+        str_rep = str_rep + "_" + str(self.n_samples)
+        str_rep = str_rep + "_" + str(self.burn_in)
+        str_rep = str_rep + "_" + str(self.thinning)
+        str_rep = str_rep + "_" + str(self.move_probs.id())
+        return str_rep

--- a/src/pyggdrasil/tree_inference/_config.py
+++ b/src/pyggdrasil/tree_inference/_config.py
@@ -22,9 +22,9 @@ class MoveProbConfig(BaseModel):
 
     def id(self) -> str:
         """String representation of move probabilities."""
-        str_rep = "MPC_" + str(self.prune_and_reattach)
-        str_rep = str_rep + "_" + str(self.swap_node_labels)
-        str_rep = str_rep + "_" + str(self.swap_subtrees)
+        str_rep = "MPC_" + f"{self.prune_and_reattach:.2}"
+        str_rep = str_rep + f"_{self.swap_node_labels:.2}"
+        str_rep = str_rep + f"_{self.swap_subtrees:.2}"
         return str_rep
 
 
@@ -41,8 +41,8 @@ class McmcConfig(BaseModel):
     def id(self) -> str:
         """String representation of MCMC config."""
         str_rep = "MC"
-        str_rep = str_rep + "_" + str(self.fpr)
-        str_rep = str_rep + "_" + str(self.fnr)
+        str_rep = str_rep + f"_{self.fpr:.3}"
+        str_rep = str_rep + f"_{self.fnr:.3}"
         str_rep = str_rep + "_" + str(self.n_samples)
         str_rep = str_rep + "_" + str(self.burn_in)
         str_rep = str_rep + "_" + str(self.thinning)

--- a/src/pyggdrasil/tree_inference/_config.py
+++ b/src/pyggdrasil/tree_inference/_config.py
@@ -59,5 +59,5 @@ class McmcConfig(BaseModel):
         str_rep = str_rep + "_" + str(self.n_samples)
         str_rep = str_rep + "_" + str(self.burn_in)
         str_rep = str_rep + "_" + str(self.thinning)
-        str_rep = str_rep + "_" + str(self.move_probs.id())
+        str_rep = str_rep + "-" + str(self.move_probs.id())
         return str_rep

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -146,9 +146,9 @@ class CellSimulationId(MutationDataId):
         self.id = self.id + "_" + str(self.na_rate)
         self.id = self.id + "_" + str(self.observe_homozygous).lower()[0]
 
-        if self.strategy is not CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT:
+        if self.strategy is CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT:
             self.id = self.id + "_" + "UXR"
-        elif self.strategy is not CellAttachmentStrategy.UNIFORM_INCLUDE_ROOT:
+        elif self.strategy is CellAttachmentStrategy.UNIFORM_INCLUDE_ROOT:
             self.id = self.id + "_" + "UIR"
 
         return self.id

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -79,17 +79,17 @@ class TreeId:
         """Creates a unique id for the tree,
         by concatenating the values of the attributes"""
 
-        self.id = "T"
-        self.id = self.id + "_" + str(self.tree_type.value)
-        self.id = self.id + "_" + str(self.n_nodes)
+        str_rep = "T"
+        str_rep = str_rep + "_" + str(self.tree_type.value)
+        str_rep = str_rep + "_" + str(self.n_nodes)
 
         if self.seed is not None:
-            self.id = self.id + "_" + str(self.seed)
+            str_rep = str_rep + "_" + str(self.seed)
 
         if self.cell_simulation_id is not None:
-            self.id = self.id + "_" + str(self.cell_simulation_id)
+            str_rep = str_rep + "_" + str(self.cell_simulation_id)
 
-        return self.id
+        return str_rep
 
     def __str__(self) -> str:
         return self.id
@@ -138,20 +138,20 @@ class CellSimulationId(MutationDataId):
         """Creates a unique id for the cell simulation,
         by concatenating the values of the attributes"""
 
-        self.id = "CS_" + str(self.seed)
-        self.id = self.id + "-" + str(self.tree_id)
-        self.id = self.id + "-" + str(self.n_cells)
-        self.id = self.id + f"_{self.fpr:.3}"
-        self.id = self.id + f"_{self.fnr:.3}"
-        self.id = self.id + f"_{self.na_rate:.3}"
-        self.id = self.id + "_" + str(self.observe_homozygous).lower()[0]
+        str_rep = "CS_" + str(self.seed)
+        str_rep = str_rep + "-" + str(self.tree_id)
+        str_rep = str_rep + "-" + str(self.n_cells)
+        str_rep = str_rep + f"_{self.fpr:.3}"
+        str_rep = str_rep + f"_{self.fnr:.3}"
+        str_rep = str_rep + f"_{self.na_rate:.3}"
+        str_rep = str_rep + "_" + str(self.observe_homozygous).lower()[0]
 
         if self.strategy is CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT:
-            self.id = self.id + "_" + "UXR"
+            str_rep = str_rep + "_" + "UXR"
         elif self.strategy is CellAttachmentStrategy.UNIFORM_INCLUDE_ROOT:
-            self.id = self.id + "_" + "UIR"
+            str_rep = str_rep + "_" + "UIR"
 
-        return self.id
+        return str_rep
 
     def __str__(self) -> str:
         return self.id
@@ -194,13 +194,13 @@ class McmcRunId:
         """Creates a unique id for the MCMC run,
         by concatenating the values of the attributes"""
 
-        self.id = "MCMC"
-        self.id = self.id + "_" + str(self.seed)
-        self.id = self.id + "-" + str(self.data)
-        self.id = self.id + "-i" + str(self.init_tree_id)
-        self.id = self.id + "-" + str(self.mcmc_config.id())
+        str_rep = "MCMC"
+        str_rep = str_rep + "_" + str(self.seed)
+        str_rep = str_rep + "-" + str(self.data)
+        str_rep = str_rep + "-i" + str(self.init_tree_id)
+        str_rep = str_rep + "-" + str(self.mcmc_config.id())
 
-        return self.id
+        return str_rep
 
     def __str__(self) -> str:
         return self.id

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -141,9 +141,9 @@ class CellSimulationId(MutationDataId):
         self.id = "CS_" + str(self.seed)
         self.id = self.id + "-" + str(self.tree_id)
         self.id = self.id + "-" + str(self.n_cells)
-        self.id = self.id + "_" + str(self.fpr)
-        self.id = self.id + "_" + str(self.fnr)
-        self.id = self.id + "_" + str(self.na_rate)
+        self.id = self.id + f"_{self.fpr:.3}"
+        self.id = self.id + f"_{self.fnr:.3}"
+        self.id = self.id + f"_{self.na_rate:.3}"
         self.id = self.id + "_" + str(self.observe_homozygous).lower()[0]
 
         if self.strategy is CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT:

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -57,8 +57,8 @@ class TreeId:
         self,
         tree_type: TreeType,
         n_nodes: int,
-        seed: Union[int, None] = None,
-        cell_simulation_id: Union[MutationDataId, None] = None,
+        seed: Optional[int] = None,
+        cell_simulation_id: Optional[MutationDataId] = None,
     ):
         """Initializes a tree id.
 

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -96,12 +96,13 @@ class TreeId:
 
 
 class CellSimulationId(MutationDataId):
-    """Class representing a cell simulation id."""
+    """Class representing a cell simulation id.
+
+    Note: that the Tree_id contains the number of mutations i.e. nodes-1"""
 
     seed: int
     tree_id: TreeId
     n_cells: int
-    n_mutations: int
     fpr: float
     fnr: float
     na_rate: float
@@ -115,7 +116,6 @@ class CellSimulationId(MutationDataId):
         seed: int,
         tree_id: TreeId,
         n_cells: int,
-        n_mutations: int,
         fpr: float,
         fnr: float,
         na_rate: float,
@@ -126,7 +126,6 @@ class CellSimulationId(MutationDataId):
         self.seed = seed
         self.tree_id = tree_id
         self.n_cells = n_cells
-        self.n_mutations = n_mutations
         self.fpr = fpr
         self.fnr = fnr
         self.na_rate = na_rate
@@ -142,7 +141,6 @@ class CellSimulationId(MutationDataId):
         self.id = "CS_" + str(self.seed)
         self.id = self.id + "-" + str(self.tree_id)
         self.id = self.id + "-" + str(self.n_cells)
-        self.id = self.id + "_" + str(self.n_mutations)
         self.id = self.id + "_" + str(self.fpr)
         self.id = self.id + "_" + str(self.fnr)
         self.id = self.id + "_" + str(self.na_rate)
@@ -198,7 +196,7 @@ class McmcRunId:
 
         self.id = "MCMC"
         self.id = self.id + "_" + str(self.seed)
-        self.id = self.id + "_" + str(self.data)
+        self.id = self.id + "-" + str(self.data)
         self.id = self.id + "-i" + str(self.init_tree_id)
         self.id = self.id + "-" + str(self.mcmc_config.id())
 

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -1,5 +1,7 @@
 """Utility Functions for _mcmc.py
 """
+from typing import TypedDict
+
 import jax.numpy as jnp
 import jax.scipy as jsp
 import xarray as xr
@@ -156,3 +158,22 @@ def unpack_sample(ds: MCMCSample) -> tuple[int, Tree, float]:
     logprobability = ds["log-probability"].item()
 
     return iteration, tree, logprobability
+
+
+class MoveProbConfig(TypedDict):
+    """Move probabilities for MCMC sampler."""
+
+    prune_and_reattach: float
+    swap_node_labels: float
+    swap_subtrees: float
+
+
+class McmcConfig(TypedDict):
+    """Config for MCMC sampler."""
+
+    move_probs: MoveProbConfig
+    fpr: float
+    fnr: float
+    num_samples: int
+    burn_in: int
+    thinning: int

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -4,7 +4,6 @@
 import jax.numpy as jnp
 import jax.scipy as jsp
 import xarray as xr
-from pydantic import BaseModel, validator
 
 from pyggdrasil.tree_inference._tree import Tree
 import pyggdrasil.tree_inference._tree as tr
@@ -158,62 +157,3 @@ def unpack_sample(ds: MCMCSample) -> tuple[int, Tree, float]:
     logprobability = ds["log-probability"].item()
 
     return iteration, tree, logprobability
-
-
-class MoveProbConfig(BaseModel):
-    """Move probabilities for MCMC sampler."""
-
-    prune_and_reattach: float
-    swap_node_labels: float
-    swap_subtrees: float
-
-    @validator("prune_and_reattach", "swap_node_labels", "swap_subtrees")
-    def move_prob_validator(cls, v):
-        """Probabilities sum to 1."""
-        total = sum(v.values())
-        if total != 1:
-            raise ValueError("Move probabilities must sum to 1")
-        return v
-
-    def id(self) -> str:
-        """String representation of move probabilities."""
-        str_rep = "MPC_" + str(self.prune_and_reattach)
-        str_rep = str_rep + "_" + str(self.swap_node_labels)
-        str_rep = str_rep + "_" + str(self.swap_subtrees)
-        return str_rep
-
-
-class McmcConfig(BaseModel):
-    """Config for MCMC sampler."""
-
-    move_probs: MoveProbConfig
-    fpr: float
-    fnr: float
-    num_samples: int
-    burn_in: int
-    thinning: int
-
-    @validator("fpr")
-    def fpr_validator(cls, v):
-        """Validate move probabilities."""
-        if v <= 0 or v > 1:
-            raise ValueError("fpr must be between 0 and 1")
-        return v
-
-    @validator("fnr")
-    def fnr_validator(cls, v):
-        """Validate move probabilities."""
-        if v <= 0 or v > 1:
-            raise ValueError("fnr must be between 0 and 1")
-        return v
-
-    def id(self) -> str:
-        """String representation of MCMC config."""
-        str_rep = "MC_"
-        str_rep = str_rep + "_" + str(self.fpr)
-        str_rep = str_rep + "_" + str(self.fnr)
-        str_rep = str_rep + "_" + str(self.num_samples)
-        str_rep = str_rep + "_" + str(self.burn_in)
-        str_rep = str_rep + "_" + str(self.thinning)
-        str_rep = str_rep + "_" + str(self.move_probs.id())
-        return str_rep

--- a/src/pyggdrasil/tree_inference/_mcmc_util.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_util.py
@@ -1,10 +1,10 @@
 """Utility Functions for _mcmc.py
 """
-from typing import TypedDict
 
 import jax.numpy as jnp
 import jax.scipy as jsp
 import xarray as xr
+from pydantic import BaseModel, validator
 
 from pyggdrasil.tree_inference._tree import Tree
 import pyggdrasil.tree_inference._tree as tr
@@ -160,15 +160,30 @@ def unpack_sample(ds: MCMCSample) -> tuple[int, Tree, float]:
     return iteration, tree, logprobability
 
 
-class MoveProbConfig(TypedDict):
+class MoveProbConfig(BaseModel):
     """Move probabilities for MCMC sampler."""
 
     prune_and_reattach: float
     swap_node_labels: float
     swap_subtrees: float
 
+    @validator("prune_and_reattach", "swap_node_labels", "swap_subtrees")
+    def move_prob_validator(cls, v):
+        """Probabilities sum to 1."""
+        total = sum(v.values())
+        if total != 1:
+            raise ValueError("Move probabilities must sum to 1")
+        return v
 
-class McmcConfig(TypedDict):
+    def id(self) -> str:
+        """String representation of move probabilities."""
+        str_rep = "MPC_" + str(self.prune_and_reattach)
+        str_rep = str_rep + "_" + str(self.swap_node_labels)
+        str_rep = str_rep + "_" + str(self.swap_subtrees)
+        return str_rep
+
+
+class McmcConfig(BaseModel):
     """Config for MCMC sampler."""
 
     move_probs: MoveProbConfig
@@ -177,3 +192,28 @@ class McmcConfig(TypedDict):
     num_samples: int
     burn_in: int
     thinning: int
+
+    @validator("fpr")
+    def fpr_validator(cls, v):
+        """Validate move probabilities."""
+        if v <= 0 or v > 1:
+            raise ValueError("fpr must be between 0 and 1")
+        return v
+
+    @validator("fnr")
+    def fnr_validator(cls, v):
+        """Validate move probabilities."""
+        if v <= 0 or v > 1:
+            raise ValueError("fnr must be between 0 and 1")
+        return v
+
+    def id(self) -> str:
+        """String representation of MCMC config."""
+        str_rep = "MC_"
+        str_rep = str_rep + "_" + str(self.fpr)
+        str_rep = str_rep + "_" + str(self.fnr)
+        str_rep = str_rep + "_" + str(self.num_samples)
+        str_rep = str_rep + "_" + str(self.burn_in)
+        str_rep = str_rep + "_" + str(self.thinning)
+        str_rep = str_rep + "_" + str(self.move_probs.id())
+        return str_rep

--- a/tests/tree_inference/test_id.py
+++ b/tests/tree_inference/test_id.py
@@ -1,0 +1,94 @@
+"""Tests for id creation for file naming."""
+
+import pytest
+
+
+from pyggdrasil.tree_inference import (
+    CellAttachmentStrategy,
+    McmcConfig,
+    MoveProbConfig,
+    TreeId,
+    CellSimulationId,
+    TreeType,
+    McmcRunId,
+)
+
+
+@pytest.fixture
+def mcmc_config() -> McmcConfig:
+    """Returns an MCMC config id."""
+
+    move_probs = MoveProbConfig()
+    mcmc_config = McmcConfig(move_probs=move_probs, n_samples=1000)
+
+    return mcmc_config
+
+
+@pytest.fixture
+def tree_id() -> TreeId:
+    """Returns a tree id."""
+
+    tree_type = TreeType.STAR
+    n_nodes = 10
+    seed = 123
+
+    return TreeId(tree_type, n_nodes, seed)
+
+
+@pytest.fixture
+def cell_simulation_id(tree_id) -> CellSimulationId:
+    """Returns a cell simulation id."""
+
+    seed = 42
+    n_cells = 1000
+    n_mutations = 100
+    fpr = 0.01
+    fnr = 0.02
+    na_rate = 0.03
+    observe_homozygous = True
+    strategy = CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT
+
+    return CellSimulationId(
+        seed,
+        tree_id,
+        n_cells,
+        n_mutations,
+        fpr,
+        fnr,
+        na_rate,
+        observe_homozygous,
+        strategy,
+    )
+
+
+@pytest.fixture
+def mcmc_run_id(cell_simulation_id, tree_id, mcmc_config) -> McmcRunId:
+    """Returns an MCMC run id."""
+
+    seed = 42
+    data = cell_simulation_id
+    init_tree_id = tree_id
+    mcmc_config = mcmc_config
+
+    return McmcRunId(seed, data, init_tree_id, mcmc_config)
+
+
+def test_tree_id(tree_id) -> None:
+    """Tests for tree id."""
+    assert str(tree_id) == "T_s_10_123"
+
+
+def test_cell_simulation_id(cell_simulation_id) -> None:
+    """Tests for cell simulation id."""
+    assert str(cell_simulation_id) == "CS_42-T_s_10_123-1000_100_0.01_0.02_0.03_t_UIR"
+
+
+def test_mcmc_run_id(mcmc_run_id) -> None:
+    """Tests for MCMC run id."""
+
+    expected_id = (
+        "MCMC_42_CS_42-T_s_10_123-1000_100_0.01_0.02_0.03_t_UIR-iT_s_10_123-MC_"
+    )
+    expected_id = expected_id + "1.24e-06_0.097_1000_0_1_MPC_0.1_0.65_0.25"
+
+    assert str(mcmc_run_id) == expected_id

--- a/tests/tree_inference/test_id.py
+++ b/tests/tree_inference/test_id.py
@@ -41,7 +41,6 @@ def cell_simulation_id(tree_id) -> CellSimulationId:
 
     seed = 42
     n_cells = 1000
-    n_mutations = 100
     fpr = 0.01
     fnr = 0.02
     na_rate = 0.03
@@ -49,15 +48,7 @@ def cell_simulation_id(tree_id) -> CellSimulationId:
     strategy = CellAttachmentStrategy.UNIFORM_EXCLUDE_ROOT
 
     return CellSimulationId(
-        seed,
-        tree_id,
-        n_cells,
-        n_mutations,
-        fpr,
-        fnr,
-        na_rate,
-        observe_homozygous,
-        strategy,
+        seed, tree_id, n_cells, fpr, fnr, na_rate, observe_homozygous, strategy
     )
 
 
@@ -80,15 +71,13 @@ def test_tree_id(tree_id) -> None:
 
 def test_cell_simulation_id(cell_simulation_id) -> None:
     """Tests for cell simulation id."""
-    assert str(cell_simulation_id) == "CS_42-T_d_10_123-1000_100_0.01_0.02_0.03_t_UIR"
+    assert str(cell_simulation_id) == "CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UIR"
 
 
 def test_mcmc_run_id(mcmc_run_id) -> None:
     """Tests for MCMC run id."""
 
-    expected_id = (
-        "MCMC_42_CS_42-T_d_10_123-1000_100_0.01_0.02_0.03_t_UIR-iT_d_10_123-MC_"
-    )
+    expected_id = "MCMC_42-CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UIR-iT_d_10_123-MC_"
     expected_id = expected_id + "1.24e-06_0.097_1000_0_1_MPC_0.1_0.65_0.25"
 
     assert str(mcmc_run_id) == expected_id

--- a/tests/tree_inference/test_id.py
+++ b/tests/tree_inference/test_id.py
@@ -71,13 +71,13 @@ def test_tree_id(tree_id) -> None:
 
 def test_cell_simulation_id(cell_simulation_id) -> None:
     """Tests for cell simulation id."""
-    assert str(cell_simulation_id) == "CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UIR"
+    assert str(cell_simulation_id) == "CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UXR"
 
 
 def test_mcmc_run_id(mcmc_run_id) -> None:
     """Tests for MCMC run id."""
 
-    expected_id = "MCMC_42-CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UIR-iT_d_10_123-MC_"
-    expected_id = expected_id + "1.24e-06_0.097_1000_0_1_MPC_0.1_0.65_0.25"
+    expected_id = "MCMC_42-CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UXR-iT_d_10_123-MC_"
+    expected_id = expected_id + "1.24e-06_0.097_1000_0_1-MPC_0.1_0.65_0.25"
 
     assert str(mcmc_run_id) == expected_id

--- a/tests/tree_inference/test_id.py
+++ b/tests/tree_inference/test_id.py
@@ -28,7 +28,7 @@ def mcmc_config() -> McmcConfig:
 def tree_id() -> TreeId:
     """Returns a tree id."""
 
-    tree_type = TreeType.STAR
+    tree_type = TreeType.DEEP
     n_nodes = 10
     seed = 123
 
@@ -75,19 +75,19 @@ def mcmc_run_id(cell_simulation_id, tree_id, mcmc_config) -> McmcRunId:
 
 def test_tree_id(tree_id) -> None:
     """Tests for tree id."""
-    assert str(tree_id) == "T_s_10_123"
+    assert str(tree_id) == "T_d_10_123"
 
 
 def test_cell_simulation_id(cell_simulation_id) -> None:
     """Tests for cell simulation id."""
-    assert str(cell_simulation_id) == "CS_42-T_s_10_123-1000_100_0.01_0.02_0.03_t_UIR"
+    assert str(cell_simulation_id) == "CS_42-T_d_10_123-1000_100_0.01_0.02_0.03_t_UIR"
 
 
 def test_mcmc_run_id(mcmc_run_id) -> None:
     """Tests for MCMC run id."""
 
     expected_id = (
-        "MCMC_42_CS_42-T_s_10_123-1000_100_0.01_0.02_0.03_t_UIR-iT_s_10_123-MC_"
+        "MCMC_42_CS_42-T_d_10_123-1000_100_0.01_0.02_0.03_t_UIR-iT_d_10_123-MC_"
     )
     expected_id = expected_id + "1.24e-06_0.097_1000_0_1_MPC_0.1_0.65_0.25"
 


### PR DESCRIPTION
This PR addresses #54 and is part of designing #53.

For a scalable snakemake workflow, I understand I need unique IDs for all my files. The current filename, whilst human readable and unique - with some flaws - results in very long filenames and is not standardized between classes - worse the naming is done is the scripts. This PR aims to create unified capabilities for all scripts ( perhaps even the `serialize` module) to call to create IDs to be incorporated into filenames. - so that snakemake has it easy. 

IDs are composed of concatenating all parameters of generation including seeds - making it reproducible - and with effort human readable - given one knows the order of parameters.

Derivatives of files needed to generate the former are carrying the generation file ID in their name. I.e. an MCMC sample will carry both an ID of the initial tree as well as the cell simulation data within it. 

This PR does not integrate the classes created here into the current workflow - will be done in future issues.

## Example IDs the current implementation generated: 
### Generated deep tree 
`T` indicates it's a tree, `d` the type of tree i.e. deep, of 10 nodes and a seed of 123
`T_d_10_123"`

### Cell simulation i.e. a mutation matrix
 generated given the above tree and a seed 42, 1000 cells, errors(0.01_0.02), a rate 0.03, homozygous mutations = true, cell attachment strategy UIR - uniform including the root 
`CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UIR`

Note how the tree is provided between the `-` carrying the information about the number of mutations =  nodes - 1

(If we ever switch to real data without a known true tree, the parent class `MutationDataId`of `CellSimulationId` may handle that and add the mutations argument back in without a tree.)

### MCMC samples
Given the tree and cell simulation data as above the mcmc samples and log will be named as follows. 

Further parameters: 
-  mcmc seed 42,
-  the initial tree here `iT_d_10_123` in the same format as above 
- Mcmc run config `MC_1.24e-06_0.097_1000_0_1` with (fpr: 1.24e-06, fnr: 0.097, n_samples: 1000, burn_in = 0, thinning = 1)
- Move Probailities Config `MPC_0.1_0.65_0.25` where the numbers are (prune_and_reattach, swap_node_labels,swap_subtrees)

The last two are implemented as `pydantic` models with default values and rudimentary checks.

The full mcmc run files have IDs like:

`MCMC_42-CS_42-T_d_10_123-1000_0.01_0.02_0.03_t_UIR-iT_d_10_123-MC_1.24e-06_0.097_1000_0_1-MPC_0.1_0.65_0.25`



