### PR TITLE
Refactor generate Trees to use TreeNode format as public API

### DIFF
--- a/scripts/run_mcmc.py
+++ b/scripts/run_mcmc.py
@@ -189,7 +189,7 @@ def run_chain(
         rng_tree, rng = random.split(rng, 2)
         #  generate random trees (uniform sampling) as adjacency matrix
         #  / add +1 for root
-        tree = tree_inf.generate_random_tree(rng_tree, n_nodes=n_mutations + 1)
+        tree = tree_inf._generate_random_tree_adj_mat(rng_tree, n_nodes=n_mutations + 1)
         tree = jnp.array(tree)
         # make Tree
         labels = jnp.arange(n_mutations + 1)
@@ -223,21 +223,21 @@ def run_chain(
             )
 
     # Make Move Probabilities
-    prune_and_reattach = config["move_probs"]["prune_and_reattach"]
-    swap_node_labels = config["move_probs"]["swap_node_labels"]
-    swap_subtrees = config["move_probs"]["swap_subtrees"]
+    prune_and_reattach = config.move_probs.prune_and_reattach
+    swap_node_labels = config.move_probs.swap_node_labels
+    swap_subtrees = config.move_probs.swap_subtrees
     move_probs = MoveProbabilities(prune_and_reattach, swap_node_labels, swap_subtrees)
 
     # run mcmc sampler
     mcmc_sampler(
         rng_key=rng,
         data=mut_mat,
-        error_rates=(config["fpr"], config["fnr"]),
+        error_rates=(config.fpr, config.fnr),
         move_probs=move_probs,
-        num_samples=config["num_samples"],
-        num_burn_in=config["burn_in"],
+        num_samples=config.n_samples,
+        num_burn_in=config.burn_in,
         output_dir=Path(params.out_dir),
-        thinning=config["thinning"],
+        thinning=config.thinning,
         init_tree=init_tree,
         timestamp=timestamp,
     )
@@ -352,7 +352,7 @@ def main() -> None:
     str_dt = get_str_timedelta(runtime)
     logging.info("Runtime: " + str_dt)
     # runtime per sample
-    runtime_per_sample = runtime / (config["num_samples"])
+    runtime_per_sample = runtime / (config.n_samples)
     runtime_per_sample_str = get_str_timedelta(runtime_per_sample)
     logging.info("Runtime per sample: " + runtime_per_sample_str)
     logging.info("Finished Session")

--- a/src/pyggdrasil/interface/__init__.py
+++ b/src/pyggdrasil/interface/__init__.py
@@ -13,7 +13,12 @@ import jax
 
 from dataclasses import dataclass
 
+
 from pyggdrasil import TreeNode
+
+# JAX random key
+JAXRandomKey = jax.random.PRNGKeyArray
+
 
 # MCMC sample in xarray format.
 # example:

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -4,7 +4,6 @@ from pyggdrasil.tree_inference._config import McmcConfig, MoveProbConfig
 
 from pyggdrasil.tree_inference._interface import (
     MutationMatrix,
-    JAXRandomKey,
     ErrorRates,
     TreeAdjacencyMatrix,
     AncestorMatrix,
@@ -69,7 +68,6 @@ __all__ = [
     "CellSimulationModel",
     "to_pure_mcmc_data",
     "check_run_for_tree",
-    "JAXRandomKey",
     "ErrorRates",
     "TreeAdjacencyMatrix",
     "get_descendants",

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -12,9 +12,9 @@ from pyggdrasil.tree_inference._interface import (
 )
 
 from pyggdrasil.tree_inference._tree_generator import (
-    _generate_random_tree_adj_mat,
-    _generate_deep_tree_adj_mat,
-    _generate_star_tree_adj_mat,
+    generate_deep_TreeNode,
+    generate_star_TreeNode,
+    generate_random_TreeNode,
 )
 
 from pyggdrasil.tree_inference._simulate import (
@@ -56,7 +56,6 @@ __all__ = [
     "add_noise_to_perfect_matrix",
     "floyd_warshall",
     "shortest_path_to_ancestry_matrix",
-    "_generate_random_tree_adj_mat",
     "adjacency_to_root_dfs",
     "get_descendants_fw",
     "mcmc_sampler",
@@ -75,8 +74,6 @@ __all__ = [
     "TreeAdjacencyMatrix",
     "get_descendants",
     "get_descendants_fw",
-    "_generate_deep_tree_adj_mat",
-    "_generate_star_tree_adj_mat",
     "AncestorMatrix",
     "CellAttachmentVector",
     "McmcConfig",
@@ -86,4 +83,7 @@ __all__ = [
     "TreeId",
     "CellSimulationId",
     "McmcRunId",
+    "generate_deep_TreeNode",
+    "generate_star_TreeNode",
+    "generate_random_TreeNode",
 ]

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -12,9 +12,9 @@ from pyggdrasil.tree_inference._interface import (
 )
 
 from pyggdrasil.tree_inference._tree_generator import (
-    generate_random_tree,
-    generate_deep_tree,
-    generate_star_tree,
+    _generate_random_tree_adj_mat,
+    _generate_deep_tree_adj_mat,
+    _generate_star_tree_adj_mat,
 )
 
 from pyggdrasil.tree_inference._simulate import (
@@ -56,7 +56,7 @@ __all__ = [
     "add_noise_to_perfect_matrix",
     "floyd_warshall",
     "shortest_path_to_ancestry_matrix",
-    "generate_random_tree",
+    "_generate_random_tree_adj_mat",
     "adjacency_to_root_dfs",
     "get_descendants_fw",
     "mcmc_sampler",
@@ -75,8 +75,8 @@ __all__ = [
     "TreeAdjacencyMatrix",
     "get_descendants",
     "get_descendants_fw",
-    "generate_deep_tree",
-    "generate_star_tree",
+    "_generate_deep_tree_adj_mat",
+    "_generate_star_tree_adj_mat",
     "AncestorMatrix",
     "CellAttachmentVector",
     "McmcConfig",

--- a/src/pyggdrasil/tree_inference/_interface.py
+++ b/src/pyggdrasil/tree_inference/_interface.py
@@ -7,11 +7,8 @@ Note:
 from typing import Union
 
 import jax
-from jax.random import PRNGKeyArray
 import numpy as np
 
-# JAX random key
-JAXRandomKey = PRNGKeyArray
 
 # Type annotation for a generic array.
 Array = Union[jax.Array, np.ndarray]

--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -15,9 +15,10 @@ import dataclasses
 import logging
 
 
+from pyggdrasil.interface import JAXRandomKey
+
 from pyggdrasil.tree_inference import (
     Tree,
-    JAXRandomKey,
     get_descendants,
 )
 

--- a/src/pyggdrasil/tree_inference/_mcmc_sampler.py
+++ b/src/pyggdrasil/tree_inference/_mcmc_sampler.py
@@ -15,6 +15,8 @@ from jax import Array
 from jax import numpy as jnp
 
 
+from pyggdrasil.interface import JAXRandomKey
+
 import pyggdrasil.tree_inference._mcmc as mcmc
 import pyggdrasil.tree_inference._logprob as logprob
 import pyggdrasil.tree_inference._mcmc_util as mcmc_util
@@ -24,7 +26,6 @@ from pyggdrasil.tree_inference._mcmc import MoveProbabilities
 from pyggdrasil.tree_inference._tree import Tree
 from pyggdrasil.tree_inference._interface import (
     MutationMatrix,
-    JAXRandomKey,
     ErrorRates,
 )
 

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, validator
 import pyggdrasil.serialize as serialize
 
 from pyggdrasil.tree_inference import (
-    generate_random_tree,
+    _generate_random_tree_adj_mat,
     JAXRandomKey,
     MutationMatrix,
     TreeAdjacencyMatrix,
@@ -640,7 +640,7 @@ def gen_sim_data(
 
     # Generate Trees
     #  generate random trees (uniform sampling) as adjacency matrix / add +1 for root
-    tree = generate_random_tree(rng_tree, n_nodes=n_mutations + 1)
+    tree = _generate_random_tree_adj_mat(rng_tree, n_nodes=n_mutations + 1)
 
     # Attach Cells To Tree
     # convert adjacency matrix to self-connected tree - in tree_inference format

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -11,9 +11,9 @@ from pydantic import BaseModel, validator
 
 import pyggdrasil.serialize as serialize
 
+from pyggdrasil.interface import JAXRandomKey
+
 from pyggdrasil.tree_inference import (
-    _generate_random_tree_adj_mat,
-    JAXRandomKey,
     MutationMatrix,
     TreeAdjacencyMatrix,
     AncestorMatrix,
@@ -21,6 +21,8 @@ from pyggdrasil.tree_inference import (
 )
 
 from pyggdrasil.tree import TreeNode
+
+from pyggdrasil.tree_inference._tree_generator import _generate_random_tree_adj_mat
 
 
 # Mutation matrix without noise

--- a/src/pyggdrasil/tree_inference/_tree_generator.py
+++ b/src/pyggdrasil/tree_inference/_tree_generator.py
@@ -9,10 +9,11 @@ import jax
 
 import numpy as np
 
-from pyggdrasil.tree_inference import JAXRandomKey
+from pyggdrasil import TreeNode
+from pyggdrasil.tree_inference import JAXRandomKey, Tree
 
 
-def generate_star_tree(n_nodes: int) -> np.ndarray:
+def _generate_star_tree_adj_mat(n_nodes: int) -> np.ndarray:
     """Generate a star tree of n_nodes nodes
        Root is the highest index node.
 
@@ -32,7 +33,26 @@ def generate_star_tree(n_nodes: int) -> np.ndarray:
     return tree
 
 
-def generate_deep_tree(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
+def generate_star_Tree(n_nodes: int) -> Tree:
+    """Generate star Tree given number of nodes.
+
+    Assumes integer labels from 0 to n_nodes - 1
+    Root node is the highest index node."""
+    adj_mat = _generate_star_tree_adj_mat(n_nodes)
+    labels = np.arange(n_nodes)
+    return Tree(jax.Array(adj_mat), jax.Array(labels))
+
+
+def generate_star_TreeNode(n_nodes: int) -> TreeNode:
+    """Generate star TreeNode tree given number of nodes.
+
+    Assumes integer labels from 0 to n_nodes - 1
+    Root node is the highest index node."""
+
+    return generate_star_Tree(n_nodes).to_TreeNode()
+
+
+def _generate_deep_tree_adj_mat(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
     """Generate a deep tree of n_nodes nodes.
 
     Args:
@@ -60,7 +80,26 @@ def generate_deep_tree(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
     return tree
 
 
-def generate_random_tree(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
+def generate_deep_Tree(rng: JAXRandomKey, n_nodes: int) -> Tree:
+    """Generate deep Tree given number of nodes.
+
+    Assumes integer labels from 0 to n_nodes - 1.
+    Root node is the highest index node."""
+    adj_mat = _generate_deep_tree_adj_mat(rng, n_nodes)
+    labels = np.arange(n_nodes)
+    return Tree(jax.Array(adj_mat), jax.Array(labels))
+
+
+def generate_deep_TreeNode(rng: JAXRandomKey, n_nodes: int) -> TreeNode:
+    """Generate deep TreeNode tree given number of nodes.
+
+    Assumes integer labels from 0 to n_nodes - 1.
+    Root node is the highest index node."""
+
+    return generate_deep_Tree(rng, n_nodes).to_TreeNode()
+
+
+def _generate_random_tree_adj_mat(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
     """
     Generates a random tree with n nodes, where the root is the highest index node.
     Nodes are not self-connected.
@@ -76,14 +115,35 @@ def generate_random_tree(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
             Note 2: the root is the last node
     """
     # Generate a random tree
-    adj_matrix = _generate_random_tree(rng, n_nodes)
+    adj_matrix = _generate_random_tree_adj_mat_unordered(rng, n_nodes)
     # Adjust the node order to convention
     adj_matrix = _reverse_node_order(adj_matrix)
 
     return adj_matrix
 
 
-def _generate_random_tree(rng: JAXRandomKey, n_nodes: int) -> np.ndarray:
+def generate_random_Tree(rng: JAXRandomKey, n_nodes: int) -> Tree:
+    """Generate random Tree given number of nodes.
+
+    Assumes integer labels from 0 to n_nodes - 1.
+    Root node is the highest index node."""
+    adj_mat = _generate_random_tree_adj_mat(rng, n_nodes)
+    labels = np.arange(n_nodes)
+    return Tree(jax.Array(adj_mat), jax.Array(labels))
+
+
+def generate_random_TreeNode(rng: JAXRandomKey, n_nodes: int) -> TreeNode:
+    """Generate random TreeNode tree given number of nodes.
+
+    Assumes integer labels from 0 to n_nodes - 1.
+    Root node is the highest index node."""
+
+    return generate_random_Tree(rng, n_nodes).to_TreeNode()
+
+
+def _generate_random_tree_adj_mat_unordered(
+    rng: JAXRandomKey, n_nodes: int
+) -> np.ndarray:
     """
     Generates a random tree with n nodes, where the root is the first node.
 

--- a/src/pyggdrasil/tree_inference/_tree_generator.py
+++ b/src/pyggdrasil/tree_inference/_tree_generator.py
@@ -10,7 +10,9 @@ import jax
 import numpy as np
 
 from pyggdrasil import TreeNode
-from pyggdrasil.tree_inference import JAXRandomKey, Tree
+from pyggdrasil.interface import JAXRandomKey
+
+from pyggdrasil.tree_inference._tree import Tree
 
 
 def _generate_star_tree_adj_mat(n_nodes: int) -> np.ndarray:

--- a/tests/tree_inference/test_analyze.py
+++ b/tests/tree_inference/test_analyze.py
@@ -7,7 +7,8 @@ import xarray as xr
 import pyggdrasil.tree_inference._analyze as analyze
 
 from pyggdrasil.interface import MCMCSample, PureMcmcData
-from pyggdrasil.tree_inference import _generate_random_tree_adj_mat, Tree
+from pyggdrasil.tree_inference._tree import Tree
+from pyggdrasil.tree_inference._tree_generator import _generate_random_tree_adj_mat
 
 
 @pytest.fixture

--- a/tests/tree_inference/test_analyze.py
+++ b/tests/tree_inference/test_analyze.py
@@ -7,7 +7,7 @@ import xarray as xr
 import pyggdrasil.tree_inference._analyze as analyze
 
 from pyggdrasil.interface import MCMCSample, PureMcmcData
-from pyggdrasil.tree_inference import generate_random_tree, Tree
+from pyggdrasil.tree_inference import _generate_random_tree_adj_mat, Tree
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def mcmc_samples() -> list[MCMCSample]:
 
     # Generate a list of random trees
     trees = [
-        generate_random_tree(rng=random.PRNGKey(j), n_nodes=10)
+        _generate_random_tree_adj_mat(rng=random.PRNGKey(j), n_nodes=10)
         for j in range(num_samples)
     ]
 
@@ -74,7 +74,9 @@ def pure_mcmc_data(mcmc_samples) -> PureMcmcData:
 def test_check_run_for_tree(pure_mcmc_data):
     """Test check_run_for_tree function."""
 
-    topology = jnp.array(generate_random_tree(rng=random.PRNGKey(1000), n_nodes=10))
+    topology = jnp.array(
+        _generate_random_tree_adj_mat(rng=random.PRNGKey(1000), n_nodes=10)
+    )
 
     labels = jnp.array([8, 2, 3, 1, 4, 7, 6, 0, 5, 9])
 

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -20,7 +20,7 @@ def test_swap_node_labels_move(seed: int):
     rng_tree, rng_nodes = random.split(rng, 2)
     # generate random tree
     n_nodes = 10
-    adj_mat = tree_inf.generate_random_tree(rng_tree, n_nodes)
+    adj_mat = tree_inf._generate_random_tree_adj_mat(rng_tree, n_nodes)
     # generate random nodes - NB: root may not be swapped, hence n_nodes-1
     node1, node2 = random.randint(rng_nodes, shape=(2,), minval=0, maxval=n_nodes - 1)
     # assign labels
@@ -114,7 +114,7 @@ def test_prune_and_reattach_moves_auto(seed: int, n_nodes: int):
     mcmc_util.prune_and_reattach_move. - automatic test"""
     rng = random.PRNGKey(seed)
     rng_adj, rng_nodes, rng_move = random.split(rng, 3)
-    tree_adj = tree_inf.generate_random_tree(rng_adj, n_nodes)
+    tree_adj = tree_inf._generate_random_tree_adj_mat(rng_adj, n_nodes)
     tree_adj = jnp.array(tree_adj)
     labels = random.permutation(rng_nodes, jnp.arange(n_nodes))
     tree = Tree(tree_adj, labels)

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -5,7 +5,7 @@ import jax.random as random
 import jax.numpy as jnp
 
 import pyggdrasil.tree_inference._mcmc as mcmc
-import pyggdrasil.tree_inference as tree_inf
+import pyggdrasil.tree_inference._tree_generator as tree_gen
 import pyggdrasil.tree_inference._tree as tr
 import pyggdrasil.tree_inference._mcmc_util as mcmc_util
 
@@ -20,7 +20,7 @@ def test_swap_node_labels_move(seed: int):
     rng_tree, rng_nodes = random.split(rng, 2)
     # generate random tree
     n_nodes = 10
-    adj_mat = tree_inf._generate_random_tree_adj_mat(rng_tree, n_nodes)
+    adj_mat = tree_gen._generate_random_tree_adj_mat(rng_tree, n_nodes)
     # generate random nodes - NB: root may not be swapped, hence n_nodes-1
     node1, node2 = random.randint(rng_nodes, shape=(2,), minval=0, maxval=n_nodes - 1)
     # assign labels
@@ -114,7 +114,7 @@ def test_prune_and_reattach_moves_auto(seed: int, n_nodes: int):
     mcmc_util.prune_and_reattach_move. - automatic test"""
     rng = random.PRNGKey(seed)
     rng_adj, rng_nodes, rng_move = random.split(rng, 3)
-    tree_adj = tree_inf._generate_random_tree_adj_mat(rng_adj, n_nodes)
+    tree_adj = tree_gen._generate_random_tree_adj_mat(rng_adj, n_nodes)
     tree_adj = jnp.array(tree_adj)
     labels = random.permutation(rng_nodes, jnp.arange(n_nodes))
     tree = Tree(tree_adj, labels)

--- a/tests/tree_inference/test_simulate.py
+++ b/tests/tree_inference/test_simulate.py
@@ -6,12 +6,12 @@ import numpy as np
 import jax.numpy as jnp
 import networkx as nx
 
-import pyggdrasil.tree_inference._interface as interface
+from pyggdrasil.interface import JAXRandomKey
 import pyggdrasil.tree_inference._simulate as sim
 
 
 def perfect_matrix(
-    rng: interface.JAXRandomKey,
+    rng: JAXRandomKey,
     positive_rate: float = 0.3,
     homozygous_rate: float = 0.1,
     shape: tuple = (100, 100),

--- a/tests/tree_inference/test_tree.py
+++ b/tests/tree_inference/test_tree.py
@@ -9,6 +9,7 @@ import json
 
 
 import pyggdrasil.tree_inference._tree as tr
+import pyggdrasil.tree_inference._tree_generator as tree_gen
 import pyggdrasil.tree_inference as tree_inf
 import pyggdrasil.serialize as serialize
 
@@ -23,7 +24,7 @@ def test_get_descendants(seed: int, n_nodes: int):
     rng = random.PRNGKey(seed)
     rng_tree, rng_nodes, rng_labels = random.split(rng, 3)
     # generate random tree
-    adj_mat = jnp.array(tree_inf._generate_random_tree_adj_mat(rng_tree, n_nodes))
+    adj_mat = jnp.array(tree_gen._generate_random_tree_adj_mat(rng_tree, n_nodes))
     # generate random nodes
     parent = int(random.randint(rng_nodes, shape=(1,), minval=0, maxval=n_nodes)[0])
     # assign labels - randomly sample

--- a/tests/tree_inference/test_tree.py
+++ b/tests/tree_inference/test_tree.py
@@ -23,7 +23,7 @@ def test_get_descendants(seed: int, n_nodes: int):
     rng = random.PRNGKey(seed)
     rng_tree, rng_nodes, rng_labels = random.split(rng, 3)
     # generate random tree
-    adj_mat = jnp.array(tree_inf.generate_random_tree(rng_tree, n_nodes))
+    adj_mat = jnp.array(tree_inf._generate_random_tree_adj_mat(rng_tree, n_nodes))
     # generate random nodes
     parent = int(random.randint(rng_nodes, shape=(1,), minval=0, maxval=n_nodes)[0])
     # assign labels - randomly sample

--- a/tests/tree_inference/test_tree_generator.py
+++ b/tests/tree_inference/test_tree_generator.py
@@ -17,7 +17,7 @@ def test_generate_random_tree(seed: int, n_nodes: int):
     # get random numbers key
     rng = random.PRNGKey(seed)
     # get random tree
-    adj_matrix = tree_inf.generate_random_tree(rng, n_nodes)
+    adj_matrix = tree_inf._generate_random_tree_adj_mat(rng, n_nodes)
     # check for number of nodes
     shape = adj_matrix.shape
     assert shape[0] == shape[1]
@@ -36,7 +36,7 @@ def test_generate_star_tree(seed: int, n_nodes: int):
     """Test generate_star_tree."""
 
     # get tree
-    adj_matrix = tree_inf.generate_star_tree(n_nodes)
+    adj_matrix = tree_inf._generate_star_tree_adj_mat(n_nodes)
     # Check the shape of the adjacency matrix
     assert adj_matrix.shape == (n_nodes, n_nodes)
     # Check if the root is the highest index node
@@ -58,7 +58,7 @@ def test_generate_deep_tree(seed: int, n_nodes: int):
     # get random numbers key
     rng = random.PRNGKey(seed)
     # get tree
-    adj_matrix = tree_inf.generate_deep_tree(rng, n_nodes)
+    adj_matrix = tree_inf._generate_deep_tree_adj_mat(rng, n_nodes)
 
     # Check the shape of the adjacency matrix
     assert adj_matrix.shape == (n_nodes, n_nodes)

--- a/tests/tree_inference/test_tree_generator.py
+++ b/tests/tree_inference/test_tree_generator.py
@@ -6,6 +6,7 @@ import numpy as np
 import jax.random as random
 import jax.numpy as jnp
 
+import pyggdrasil.tree_inference._tree_generator as tree_gen
 import pyggdrasil.tree_inference as tree_inf
 
 
@@ -17,7 +18,7 @@ def test_generate_random_tree(seed: int, n_nodes: int):
     # get random numbers key
     rng = random.PRNGKey(seed)
     # get random tree
-    adj_matrix = tree_inf._generate_random_tree_adj_mat(rng, n_nodes)
+    adj_matrix = tree_gen._generate_random_tree_adj_mat(rng, n_nodes)
     # check for number of nodes
     shape = adj_matrix.shape
     assert shape[0] == shape[1]
@@ -36,7 +37,7 @@ def test_generate_star_tree(seed: int, n_nodes: int):
     """Test generate_star_tree."""
 
     # get tree
-    adj_matrix = tree_inf._generate_star_tree_adj_mat(n_nodes)
+    adj_matrix = tree_gen._generate_star_tree_adj_mat(n_nodes)
     # Check the shape of the adjacency matrix
     assert adj_matrix.shape == (n_nodes, n_nodes)
     # Check if the root is the highest index node
@@ -58,7 +59,7 @@ def test_generate_deep_tree(seed: int, n_nodes: int):
     # get random numbers key
     rng = random.PRNGKey(seed)
     # get tree
-    adj_matrix = tree_inf._generate_deep_tree_adj_mat(rng, n_nodes)
+    adj_matrix = tree_gen._generate_deep_tree_adj_mat(rng, n_nodes)
 
     # Check the shape of the adjacency matrix
     assert adj_matrix.shape == (n_nodes, n_nodes)


### PR DESCRIPTION
This PR addresses #59.

Some minor refactoring was done in `run_mcmc.py` just because `pyright` did just catch it here.