### PR TITLE
Revised version of Cell Simulation

### DIFF
--- a/scripts/cell_simulation.py
+++ b/scripts/cell_simulation.py
@@ -23,6 +23,7 @@ import json
 import os
 
 import pyggdrasil.tree_inference as tree_inf
+import pyggdrasil.serialize as serialize
 
 from pyggdrasil.tree_inference import CellSimulationModel, CellSimulationId, TreeId
 from pyggdrasil.serialize import JnpEncoder
@@ -131,6 +132,9 @@ def run_sim(params: argparse.Namespace) -> None:
 
     tree_id = TreeId.from_str(tt_filename_without_extension)
 
+    # Load the tree from the file
+    tree = serialize.read_tree_node(true_tree_fp)
+
     ###############################
     # Get Cell Simulation Id and set up CellSimulationModel
     ###############################
@@ -157,7 +161,7 @@ def run_sim(params: argparse.Namespace) -> None:
     # Create a random number generator
     rng = random.PRNGKey(params.seed)
     # Generate Data
-    data = tree_inf.gen_sim_data(params_model, rng)
+    data = tree_inf.gen_sim_data(params_model, rng, tree)
 
     ###############################
     # Save Data to Disk

--- a/src/pyggdrasil/serialize/_to_json.py
+++ b/src/pyggdrasil/serialize/_to_json.py
@@ -131,16 +131,16 @@ def save_tree_node(Tree: TreeNode, output_fp: Path):
         json.dump(tree_node, f, cls=JnpEncoder)
 
 
-def read_tree_node(output_fp: Path):
+def read_tree_node(fp: Path) -> TreeNode:
     """Reads Json file to Tree object from disk.
 
     Args:
-        output_fp: directory to save tree to
+        fp: directory to save tree to
     Returns:
         None
     """
 
-    with open(output_fp, "r") as f:
+    with open(fp, "r") as f:
         tree_node = json.load(f)
 
     return deserialize_tree_from_dict(tree_node, deserialize_data=lambda x: x)
@@ -154,6 +154,7 @@ def save_mcmc_sample(
     Args:
         sample: MCMC sample to be saved
         output_dir: directory to save sample to
+        timestamp: timestamp to be added to filename
 
     Returns:
         None

--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -17,6 +17,8 @@ from pyggdrasil.tree_inference._tree_generator import (
     generate_star_tree,
 )
 
+from pyggdrasil.tree_inference._tree import Tree, tree_from_tree_node, get_descendants
+
 from pyggdrasil.tree_inference._simulate import (
     CellAttachmentStrategy,
     attach_cells_to_tree,
@@ -36,8 +38,6 @@ from pyggdrasil.tree_inference._file_id import (
     CellSimulationId,
     McmcRunId,
 )
-
-from pyggdrasil.tree_inference._tree import Tree, tree_from_tree_node, get_descendants
 
 from pyggdrasil.tree_inference._mcmc_util import (
     unpack_sample,

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -94,6 +94,23 @@ class TreeId:
     def __str__(self) -> str:
         return self.id
 
+    @classmethod
+    def from_str(cls, str_id: str):
+        """Creates a tree id from a string representation of the id.
+
+        Args:
+            str_id: str
+        """
+        # split string by underscore and assign to attributes
+        _, tree_type, n_nodes, seed = str_id.split("_")
+
+        if seed is not None:
+            tree_id = TreeId(TreeType(tree_type), int(n_nodes), int(seed))
+            return tree_id
+        else:
+            tree_id = TreeId(TreeType(tree_type), int(n_nodes))
+            return tree_id
+
 
 class CellSimulationId(MutationDataId):
     """Class representing a cell simulation id.

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -23,8 +23,6 @@ from pyggdrasil.tree_inference import (
 
 from pyggdrasil.tree import TreeNode
 
-from pyggdrasil.tree_inference._tree_generator import _generate_random_tree_adj_mat
-
 
 # Mutation matrix without noise
 # Represents mutations in sampled cells (n_sites, n_cells)

--- a/src/pyggdrasil/tree_inference/_tree_generator.py
+++ b/src/pyggdrasil/tree_inference/_tree_generator.py
@@ -6,6 +6,7 @@ All Adjacency matrices are assumed to be directed, and to have no self-connectio
 Note: this is part of the private API.
 """
 import jax
+import jax.numpy as jnp
 
 import numpy as np
 
@@ -42,7 +43,7 @@ def generate_star_Tree(n_nodes: int) -> Tree:
     Root node is the highest index node."""
     adj_mat = _generate_star_tree_adj_mat(n_nodes)
     labels = np.arange(n_nodes)
-    return Tree(jax.Array(adj_mat), jax.Array(labels))
+    return Tree(jnp.array(adj_mat), jnp.array(labels))
 
 
 def generate_star_TreeNode(n_nodes: int) -> TreeNode:
@@ -89,7 +90,7 @@ def generate_deep_Tree(rng: JAXRandomKey, n_nodes: int) -> Tree:
     Root node is the highest index node."""
     adj_mat = _generate_deep_tree_adj_mat(rng, n_nodes)
     labels = np.arange(n_nodes)
-    return Tree(jax.Array(adj_mat), jax.Array(labels))
+    return Tree(jnp.array(adj_mat), jnp.array(labels))
 
 
 def generate_deep_TreeNode(rng: JAXRandomKey, n_nodes: int) -> TreeNode:
@@ -131,7 +132,7 @@ def generate_random_Tree(rng: JAXRandomKey, n_nodes: int) -> Tree:
     Root node is the highest index node."""
     adj_mat = _generate_random_tree_adj_mat(rng, n_nodes)
     labels = np.arange(n_nodes)
-    return Tree(jax.Array(adj_mat), jax.Array(labels))
+    return Tree(jnp.array(adj_mat), jnp.array(labels))
 
 
 def generate_random_TreeNode(rng: JAXRandomKey, n_nodes: int) -> TreeNode:

--- a/tests/tree_inference/test_id.py
+++ b/tests/tree_inference/test_id.py
@@ -81,3 +81,12 @@ def test_mcmc_run_id(mcmc_run_id) -> None:
     expected_id = expected_id + "1.24e-06_0.097_1000_0_1-MPC_0.1_0.65_0.25"
 
     assert str(mcmc_run_id) == expected_id
+
+
+def test_tree_id_from_str(tree_id) -> None:
+    """Tests for tree id."""
+    test_id = TreeId.from_str(str(tree_id))
+
+    assert test_id.tree_type == tree_id.tree_type
+    assert test_id.n_nodes == tree_id.n_nodes
+    assert test_id.seed == tree_id.seed

--- a/tests/tree_inference/test_simulate.py
+++ b/tests/tree_inference/test_simulate.py
@@ -458,10 +458,8 @@ def tree_tn() -> TreeNode:
     """Fixture for a TreeNode object - for gen_sim_data test."""
     n_nodes = 9
     rng = random.PRNGKey(42)
-    tree_adj = jnp.array(tree_inf.generate_random_tree(rng, n_nodes))
-    tree_labels = jnp.arange(n_nodes)
-    tree = tree_inf.Tree(tree_adj, tree_labels)
-    return tree.to_TreeNode()
+
+    return tree_inf.generate_random_TreeNode(rng, n_nodes)
 
 
 def test_gen_sim_data(tree_tn):

--- a/tests/tree_inference/test_simulate.py
+++ b/tests/tree_inference/test_simulate.py
@@ -6,8 +6,11 @@ import numpy as np
 import jax.numpy as jnp
 import networkx as nx
 
+from pyggdrasil.tree import TreeNode
+
 import pyggdrasil.tree_inference._interface as interface
 import pyggdrasil.tree_inference._simulate as sim
+import pyggdrasil.tree_inference as tree_inf
 
 
 def perfect_matrix(
@@ -448,7 +451,18 @@ def test_attach_cells_to_tree_case1(
     assert np.array_equal(mutation_matrix, mutation_matrix_true)
 
 
-def test_gen_sim_data():
+@pytest.fixture
+def tree_tn() -> TreeNode:
+    """Fixture for a TreeNode object - for gen_sim_data test."""
+    n_nodes = 9
+    rng = random.PRNGKey(42)
+    tree_adj = jnp.array(tree_inf.generate_random_tree(rng, n_nodes))
+    tree_labels = jnp.arange(n_nodes)
+    tree = tree_inf.Tree(tree_adj, tree_labels)
+    return tree.to_TreeNode()
+
+
+def test_gen_sim_data(tree_tn):
     """Test that the dimensions of the mock data are correct."""
 
     params = {
@@ -466,15 +480,15 @@ def test_gen_sim_data():
 
     params_ty = sim.CellSimulationModel(**params)
 
-    data = sim.gen_sim_data(params_ty, rng)
+    data = sim.gen_sim_data(params_ty, rng, tree_tn)
 
     # check that the dimensions of the data are correct
     assert np.array(data["adjacency_matrix"]).shape == (8 + 1, 8 + 1)
     assert np.array(data["noisy_mutation_mat"]).shape == (
         8,
         100,
-    )  # TODO: to be altered if we truncate the matrix
+    )
     assert np.array(data["perfect_mutation_mat"]).shape == (
         8,
         100,
-    )  # TODO: to be altered if we truncate the matrix
+    )


### PR DESCRIPTION
In this PR, I revised the `cell_simulation.py` scripts for the mock data generation to 
- use the new file naming provided by `tree_inference.CellSimulationId` 
- generate one mock data set for one tree given (allowing to supply the true tree instead of adhock random generation)

