### PR TITLE
Fixing Tree Move Bugs #2

### DIFF
--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -96,15 +96,16 @@ def _prune_and_reattach_proposal(key: JAXRandomKey, tree: Tree) -> Tuple[Tree, f
 def _swap_node_labels_move(tree: Tree, node1: int, node2: int) -> Tree:
     """Swaps labels between ``node1`` and ``node2`` leaving the tree topology
     untouched."""
-    label1 = tree.labels[node1]
-    label2 = tree.labels[node2]
+
+    node1_idx = jnp.where(tree.labels == node1)[0]
+    node2_idx = jnp.where(tree.labels == node2)[0]
 
     # Copy all the labels
     new_labels = tree.labels
     # Assign label2 to node1...
-    new_labels = new_labels.at[node1].set(label2)
+    new_labels = new_labels.at[node1_idx].set(node2)
     # ... and label1 to node2
-    new_labels = new_labels.at[node2].set(label1)
+    new_labels = new_labels.at[node2_idx].set(node1)
 
     logger.debug(
         "MCMC: Swap node labels move - swapped labels of node %s and node %s",

--- a/src/pyggdrasil/tree_inference/_mcmc.py
+++ b/src/pyggdrasil/tree_inference/_mcmc.py
@@ -79,10 +79,23 @@ def _prune_and_reattach_proposal(key: JAXRandomKey, tree: Tree) -> Tuple[Tree, f
     rng_prune, rng_reattach = random.split(key)
     # pick a random non-root node to prune
     pruned_node = int(random.choice(rng_prune, tree.labels[:-1]))
+
+    # TODO (Gordon) : consider to remove if checks passed
+    logger.debug("MCMC: Prune and reattach move - pruned node %s", pruned_node)
+
     # get descendants of pruned node
-    descendants = get_descendants(tree.tree_topology, tree.labels, pruned_node)
-    # possible nodes to reattach to - including pruned node for aperiodic case
+    descendants = get_descendants(
+        tree.tree_topology, tree.labels, pruned_node, include_parent=True
+    )
+    # possible nodes to reattach to - no descendants of pruned node,
+    # nor pruned node itself, but root
     possible_nodes = jnp.setdiff1d(tree.labels, descendants)
+
+    # TODO (Gordon) : consider to remove if checks passed
+    logger.debug(
+        "MCMC: Prune and reattach move - possible nodes to reattach to: %s",
+        possible_nodes,
+    )
     # pick a random node to reattach to
     attach_to = int(random.choice(rng_reattach, possible_nodes))
     return (
@@ -420,6 +433,15 @@ def _mcmc_kernel(
     u = random.uniform(key_acceptance)
     if u <= acceptance_ratio:
         logger.info("Move Accepted")
+
+        # TODO (Gordon): remove after debugging
+        logger.debug(f"Tree:\n  {proposal}")
+        try:
+            tn = proposal.to_TreeNode()
+            logger.debug(f"TreeNode:\n {tn}")
+        except Exception:
+            logger.debug("Could not convert to TreeNode")
+
         return proposal, logprob_proposal
     else:
         logger.info("Move Rejected")

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -10,6 +10,7 @@ import numpy as np
 import jax.numpy as jnp
 from jax import Array
 import logging
+import pandas as pd
 
 from pyggdrasil.tree import TreeNode
 import pyggdrasil.tree_inference as tree_inf
@@ -67,6 +68,14 @@ class Tree:
     def print_topo(self):
         """Prints the tree in a human-readable format."""
         return self.to_TreeNode().print_topo()
+
+    def __str__(self):
+        labels = self.labels
+        assert labels is not None
+        df = pd.DataFrame(
+            self.tree_topology.astype(int), labels, labels  # type: ignore
+        )
+        return df.__str__()
 
 
 def _resort_root_to_end(tree: Tree, root: int) -> Tree:
@@ -213,12 +222,16 @@ def _get_root_label(tree: Tree) -> int:
     root_idx = jnp.where(jnp.all(ancestor_matrix == 1, axis=1))[0]
     if len(root_idx) > 1:
         logger.error("More than one root found - not a tree")
+        logger.error(f"labels: {tree.labels}")
+        logger.error(f"tree topology:\n {tree.tree_topology}")
         raise ValueError("More than one root found - not a tree")
     elif len(root_idx) == 0:
         logger.error("No root found - not a tree")
+        logger.error(f"labels: {tree.labels}")
+        logger.error(f"tree topology:\n {tree.tree_topology}")
         raise ValueError("No root found - not a tree")
     # get root label
-    root_label = int(tree.labels[root_idx])
+    root_label = int(tree.labels[root_idx][0])
 
     return root_label
 

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -222,16 +222,16 @@ def _get_root_label(tree: Tree) -> int:
     root_idx = jnp.where(jnp.all(ancestor_matrix == 1, axis=1))[0]
     if len(root_idx) > 1:
         logger.error("More than one root found - not a tree")
-        logger.error(f"labels: {tree.labels}")
-        logger.error(f"tree topology:\n {tree.tree_topology}")
+        logger.error(f"Tree: \n {tree}")
         raise ValueError("More than one root found - not a tree")
     elif len(root_idx) == 0:
         logger.error("No root found - not a tree")
-        logger.error(f"labels: {tree.labels}")
-        logger.error(f"tree topology:\n {tree.tree_topology}")
+        logger.error(f"Tree: \n {tree}")
         raise ValueError("No root found - not a tree")
     # get root label
     root_label = int(tree.labels[root_idx][0])
+
+    logger.info(f"Tree: \n {tree}")
 
     return root_label
 

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -231,8 +231,6 @@ def _get_root_label(tree: Tree) -> int:
     # get root label
     root_label = int(tree.labels[root_idx][0])
 
-    logger.info(f"Tree: \n {tree}")
-
     return root_label
 
 

--- a/src/pyggdrasil/tree_inference/_tree.py
+++ b/src/pyggdrasil/tree_inference/_tree.py
@@ -321,3 +321,31 @@ def is_same_tree(tree1: Tree, tree2: Tree) -> bool:
         ) and jnp.all(tree1.labels == tree2_reordered.labels)
 
     return bool(result)
+
+
+def is_valid_tree(tree: Tree) -> bool:
+    """Validates a tree
+     for
+    1. Single root
+    2. No self-loops
+    3. All components are connected
+    4. Correct dimensions
+    """
+
+    # try conversion to TreeNode
+    try:
+        tree.to_TreeNode()
+    except Exception as e:
+        print(e)
+        logger.error("Tree is not valid")
+        print("Tree is not valid")
+        return False
+
+    # Check if dimensions are correct
+    num_nodes = len(tree.labels)
+    if tree.tree_topology.shape != (num_nodes, num_nodes):
+        logger.error("Tree topology has incorrect dimensions")
+        print("Tree topology has incorrect dimensions")
+        return False
+
+    return True

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -349,3 +349,44 @@ def test_swap_subtrees_move_fig17_nested_subtrees(seed):
     )
     # check if the labels are the same, just once for sanity
     assert jnp.array_equal(new_tree.labels, new_tree_corr1.labels)
+
+
+def test_swap_node_labels_manual():
+    """Test mcmc.swap_node_labels_move  - manual test
+    Bug was found in deep tree mcmc runs."""
+
+    # Original tree
+    tree_adj = jnp.array(
+        [
+            # 3  0  1  2  4
+            [0, 1, 0, 0, 0],  # 3
+            [0, 0, 1, 0, 0],  # 0
+            [0, 0, 0, 1, 0],  # 1
+            [0, 0, 0, 0, 0],  # 2
+            [1, 0, 0, 0, 0],  # 4
+        ]
+    )
+    labels = jnp.array([3, 0, 1, 2, 4])
+    tree = Tree(tree_adj, labels)
+
+    new_tree = mcmc._swap_node_labels_move(tree, node1=0, node2=3)
+
+    print("Tree after swap")
+    print(new_tree)
+
+    # Expected tree
+    tree_adj = jnp.array(
+        [
+            # 0  3  1  2  4
+            [0, 1, 0, 0, 0],  # 0
+            [0, 0, 1, 0, 0],  # 3
+            [0, 0, 0, 1, 0],  # 1
+            [0, 0, 0, 0, 0],  # 2
+            [1, 0, 0, 0, 0],  # 4
+        ]
+    )
+    labels = jnp.array([0, 3, 1, 2, 4])
+    expected_tree = Tree(tree_adj, labels)
+
+    assert jnp.array_equal(new_tree.tree_topology, expected_tree.tree_topology)
+    assert jnp.array_equal(new_tree.labels, expected_tree.labels)

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -390,3 +390,40 @@ def test_swap_node_labels_manual():
 
     assert jnp.array_equal(new_tree.tree_topology, expected_tree.tree_topology)
     assert jnp.array_equal(new_tree.labels, expected_tree.labels)
+
+
+def test_prune_and_reattach_deep_tree():
+    """Test prune and reattach move again - manual test"""
+
+    # Original tree
+    tree_adj = jnp.array(
+        [
+            # 1  0  2  3  4
+            [0, 1, 0, 0, 0],  # 1
+            [0, 0, 1, 0, 0],  # 0
+            [0, 0, 0, 1, 0],  # 2
+            [0, 0, 0, 0, 0],  # 3
+            [1, 0, 0, 0, 0],  # 4
+        ]
+    )
+    labels = jnp.array([1, 0, 2, 3, 4])
+    tree = Tree(tree_adj, labels)
+
+    new_tree = mcmc._prune_and_reattach_move(tree, pruned_node=0, attach_to=4)
+
+    # Expected tree
+    tree_adj = jnp.array(
+        [
+            # 1  0  2  3  4
+            [0, 0, 0, 0, 0],  # 1
+            [0, 0, 1, 0, 0],  # 0
+            [0, 0, 0, 1, 0],  # 2
+            [0, 0, 0, 0, 0],  # 3
+            [1, 1, 0, 0, 0],  # 4
+        ]
+    )
+    labels = jnp.array([1, 0, 2, 3, 4])
+    expected_tree = Tree(tree_adj, labels)
+
+    assert jnp.array_equal(new_tree.tree_topology, expected_tree.tree_topology)
+    assert jnp.array_equal(new_tree.labels, expected_tree.labels)

--- a/tests/tree_inference/test_mcmc.py
+++ b/tests/tree_inference/test_mcmc.py
@@ -8,6 +8,7 @@ import pyggdrasil.tree_inference._mcmc as mcmc
 import pyggdrasil.tree_inference._tree_generator as tree_gen
 import pyggdrasil.tree_inference._tree as tr
 import pyggdrasil.tree_inference._mcmc_util as mcmc_util
+from pyggdrasil.tree_inference import MoveProbConfigOptions
 
 from pyggdrasil.tree_inference._tree import Tree
 
@@ -427,3 +428,53 @@ def test_prune_and_reattach_deep_tree():
 
     assert jnp.array_equal(new_tree.tree_topology, expected_tree.tree_topology)
     assert jnp.array_equal(new_tree.labels, expected_tree.labels)
+
+
+def make_tree(n: int, seed: int, tree_type: str) -> Tree:
+    """Make a tree for testing."""
+
+    rng = random.PRNGKey(seed)
+
+    if tree_type == "r":
+        adj_mat = jnp.array(tree_gen._generate_random_tree_adj_mat(rng, n))
+        labels = jnp.arange(n)
+        return Tree(adj_mat, labels)
+    elif tree_type == "s":
+        adj_mat = jnp.array(tree_gen._generate_star_tree_adj_mat(n))
+        labels = jnp.arange(n)
+        return Tree(adj_mat, labels)
+    else:
+        adj_mat = jnp.array(tree_gen._generate_deep_tree_adj_mat(rng, n))
+        labels = jnp.arange(n)
+        return Tree(adj_mat, labels)
+
+
+@pytest.mark.parametrize("tree_type", ["r", "s", "d"])
+@pytest.mark.parametrize("n_nodes", [5, 10])
+@pytest.mark.parametrize("tree_seed", [34])
+@pytest.mark.parametrize("n_moves", [25])
+@pytest.mark.parametrize("seed", [97])
+def test_mcmc_kernel(tree_type, n_nodes, seed, n_moves, tree_seed):
+    """Test mcmc kernel - i.e. test that 200 moves for some tree are all valid"""
+
+    # Make a tree
+    tree = make_tree(n_nodes, seed, tree_type)
+
+    # define move probabilities
+    move_probs = MoveProbConfigOptions.DEFAULT.value
+
+    # get rng
+    rng = random.PRNGKey(tree_seed)
+
+    # make random log prob function
+    def log_prob_fn(t: Tree) -> float:
+        """Log prob function for testing. - dummy function"""
+        return random.uniform(rng, shape=()).__float__()
+
+    # Run the kernel
+    for i in range(n_moves):
+        rng, rng_now = random.split(rng)
+        tree, _ = mcmc._mcmc_kernel(
+            rng_now, tree, move_probs, log_prob_fn  # type: ignore
+        )
+        assert tr.is_valid_tree(tree)

--- a/tests/tree_inference/test_tree.py
+++ b/tests/tree_inference/test_tree.py
@@ -15,6 +15,10 @@ import pyggdrasil.serialize as serialize
 
 from pyggdrasil.tree_inference._tree import Tree
 
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
 
 @pytest.mark.parametrize("seed", [42, 32, 44])
 @pytest.mark.parametrize("n_nodes", [5, 10, 15])
@@ -221,3 +225,32 @@ def test_is_not_same_tree():
     tree2 = Tree(adj_mat2, labels2)
 
     assert tr.is_same_tree(tree1, tree2) is False
+
+
+def make_tree(n: int, seed: int, tree_type: str) -> Tree:
+    """Make a tree for testing."""
+
+    rng = random.PRNGKey(seed)
+
+    if tree_type == "r":
+        adj_mat = jnp.array(tree_gen._generate_random_tree_adj_mat(rng, n))
+        labels = jnp.arange(n)
+        return Tree(adj_mat, labels)
+    elif tree_type == "s":
+        adj_mat = jnp.array(tree_gen._generate_star_tree_adj_mat(n))
+        labels = jnp.arange(n)
+        return Tree(adj_mat, labels)
+    else:
+        adj_mat = jnp.array(tree_gen._generate_deep_tree_adj_mat(rng, n))
+        labels = jnp.arange(n)
+        return Tree(adj_mat, labels)
+
+
+@pytest.mark.parametrize("n", [5, 10])
+@pytest.mark.parametrize("seed", [34, 424])
+@pytest.mark.parametrize("tree_type", ["r", "s", "d"])
+def test_is_valid_tree(n: int, seed: int, tree_type: str):
+    """Test is_valid_tree function."""
+
+    tree = make_tree(n, seed, tree_type)
+    assert tr.is_valid_tree(tree) is True


### PR DESCRIPTION
This PR addresses 
- #83 

During the development of 
- #82 
some trees generated in the mcmc chain of an initial deep tree could again not be converted to `TreeNodes`, no root was there. The tree was broken. 

There must be a bug in the mcmc moves. After already having fixed one in 
- #48 
and running chains of hundreds of samples it is surprising to see this. Glad to find the bugs now. 
It appears small deep trees test the extreme cases of the tree moves.

So far I have found 2 bugs. One in 
- `_prune_and_reattach_proposal` : the pruned node itself was included in the potential nodes to reattach to
-`_swap_node_labels_move` : confused node levels with indices

I have lost trust in these moves, I have already added test functions, but it is about time to test these moves thoroughly. I'll add tests as proposed in, i.e. this PR also closes
- #14 
