### PR TITLE
Enforce Unique Star Tree Filenames

### DIFF
--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -72,6 +72,9 @@ class TreeId:
             seed: int
         """
 
+        if tree_type == TreeType.STAR and seed is not None:
+            raise AssertionError("Star tree cannot have a seed")
+
         self.tree_type = tree_type
         self.n_nodes = n_nodes
         self.seed = seed

--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -45,7 +45,7 @@ class TreeId:
 
     tree_type: TreeType - type of tree
     n_nodes: int - number of nodes in the tree
-    seed: int - seed used to generate the tree
+    seed: int - seed used to generate the tree, not required for star tree
     cell_simulation_id: str - if the tree was generated from a cell
                                 simulation, i.e. Huntress
     """

--- a/workflows/mark01.smk
+++ b/workflows/mark01.smk
@@ -62,7 +62,10 @@ def make_all_mark01()->list[str]:
             for n_node in n_nodes:
 
                 # make true tree id
-                tree_id = TreeId(tree_type=TreeType(tree_type), n_nodes=n_node, seed=tree_seed)
+                if tree_type == "s": # star trees have no seed
+                    tree_id = TreeId(tree_type=TreeType(tree_type), n_nodes=n_node)
+                else:
+                    tree_id = TreeId(tree_type=TreeType(tree_type), n_nodes=n_node, seed=tree_seed)
 
                 for n_cell in n_cells:
                         for error_name, error in errors.items():


### PR DESCRIPTION
During the first full run of the `MARK01` experiment, snakemake could not handle some ambiguity of star trees with seeds. 

As only one star tree exist per number of nodes, yet the workflow was able to generate `TreeId`s, the error only appeared in the final snakemake rules. 

To avoid this late appearance of the issue, I added an `AssertionError` in the creation of a `TreeId`. 

No star tree should be double-generated now. 