### PR TITLE
Cleanup Print Statements

### DIFF
--- a/src/pyggdrasil/tree_inference/_file_id.py
+++ b/src/pyggdrasil/tree_inference/_file_id.py
@@ -214,7 +214,6 @@ class CellSimulationId(MutationDataId):
         parts = str_id.split("-")
         cs_part1 = parts[0]
         tree_id = parts[1]
-        print(tree_id)
         cs_part2 = "-".join(parts[2:])
 
         # check prefix and postfix


### PR DESCRIPTION
Removing print statement in `tree_inference._file.id` that slipped through after debugging.