### PR TITLE
Revising MARK02

### DIFF
--- a/src/pyggdrasil/analyze/_metrics.py
+++ b/src/pyggdrasil/analyze/_metrics.py
@@ -15,7 +15,7 @@ class Metrics:
         return Metrics._METRICS[metric]
 
     _METRICS: Dict[str, Callable[[TreeNode, TreeNode], float]] = {  # type: ignore
-        "AD": AncestorDescendantSimilarity.calculate,
+        "AD": AncestorDescendantSimilarity().calculate,
         "MP3": MP3Similarity().calculate,
         "TrueTree": compare_trees,
     }


### PR DESCRIPTION
The first run of MARK02 was a success. All plots but the MCMC calculations have run. 

The MP3 distance has generated interesting histograms.

The AD distance failed due to a simple `()` initialization of an object for the AD. 

Should work now.

