### PR TITLE
Revision MARK01

### DIFF
--- a/scripts/make_huntress.py
+++ b/scripts/make_huntress.py
@@ -134,7 +134,7 @@ def main() -> None:
     mut_mat = cell_simulation_data["noisy_mutation_mat"]
 
     # run huntress tree inference
-    tree_n = huntress_tree_inference(mut_mat, args.fpr, args.fnr)
+    tree_n = huntress_tree_inference(mut_mat, args.fpr, args.fnr, n_threads=2)
     tree_tn = TreeNode(name=tree_n.name, parent=None, children=tree_n.children)
 
     # Save the tree - make path

--- a/workflows/mark01.smk
+++ b/workflows/mark01.smk
@@ -30,7 +30,7 @@ errors = {
         for member in yg.tree_inference.ErrorCombinations
 }
 n_mutations = [5, 10, 30, 50] # <-- configure number of mutations here
-n_cells = [200, 1000, 5000] # <-- configure number of cells here
+n_cells = [200, 1000] #, 5000] # <-- configure number of cells here
 
 # Homozygous mutations [f: False / t: True]
 observe_homozygous = "f" # <-- configure whether to observe homozygous mutations here

--- a/workflows/mark01.smk
+++ b/workflows/mark01.smk
@@ -30,7 +30,7 @@ errors = {
         for member in yg.tree_inference.ErrorCombinations
 }
 n_mutations = [5, 10, 30, 50] # <-- configure number of mutations here
-n_cells = [200, 1000] #, 5000] # <-- configure number of cells here
+n_cells = [200, 1000, 5000] # <-- configure number of cells here
 
 # Homozygous mutations [f: False / t: True]
 observe_homozygous = "f" # <-- configure whether to observe homozygous mutations here


### PR DESCRIPTION
On 4 h subjobs the HUNTRESS calculation seems to time out for 5000 cells, see the error message below. 

It may be worth considering removing the constraint of the number of `threads=1` of huntress. 

In this PR I am changing the number of threads used to 2.

And using higher runtime jobs.


```
[Thu Jul  6 23:22:48 2023]
rule run_huntress:
    input: /cluster/work/bewi/members/gkoehn/data/mark01/mutations/CS_16-T_s_51-5000_1e-06_1e-06_0.0_f_UXR.json
    output: /cluster/work/bewi/members/gkoehn/data/mark01/huntress/HUN-CS_16-T_s_51-5000_1e-06_1e-06_0.0_f_UXR.json
    jobid: 56519
    reason: Missing output files: /cluster/work/bewi/members/gkoehn/data/mark01/huntress/HUN-CS_16-T_s_51-5000_1e-06_1e-06_0.0_f_UXR.json
    wildcards: DATADIR=/cluster/work/bewi/members/gkoehn/data, experiment=mark01, mutation_data_id=CS_16-T_s_51-5000_1e-06_1e-06_0.0_f_UXR
    resources: mem_mb=2000, mem_mib=1908, disk_mb=1000, disk_mib=954, tmpdir=<TBD>, runtime=239

Submitted job 56519 with external jobid '20534848'.
slurmstepd: error: *** JOB 20534454 ON eu-g5-048-4 CANCELLED AT 2023-07-09T23:18:43 DUE TO TIME LIMIT ***
Will exit after finishing currently running jobs (scheduler).
```
