### PR TITLE
Fixing Mark03 rule error

### DIFF
--- a/workflows/analyze.smk
+++ b/workflows/analyze.smk
@@ -16,6 +16,8 @@ rule analyze_metric:
         base_tree = '{DATADIR}/{experiment}/trees/{base_tree_id}.json'
     wildcard_constraints:
         mcmc_config_id = "MC.*",
+        # metric wildcard cannot be log_prob
+        metric=r"(?!(log_prob))\w+",
     output:
         result="{DATADIR}/{experiment}/analysis/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}/{base_tree_id}/{metric}.json",
         log="{DATADIR}/{experiment}/analysis/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}/{base_tree_id}/{metric}.log",

--- a/workflows/analyze.smk
+++ b/workflows/analyze.smk
@@ -50,6 +50,10 @@ rule get_log_probs:
     """Extract log probabilities from MCMC samples for ease of plotting / analysis."""
     input:
         mcmc_samples="{DATADIR}/{experiment}/mcmc/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}.json",
+    wildcard_constraints:
+        mcmc_config_id = "MC_(?:(?!/).)+",
+        init_tree_id = "(HUN|T)_(?:(?!/).)+"
+
     output:
         result="{DATADIR}/{experiment}/analysis/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}/log_prob.json",
     run:

--- a/workflows/mark02.smk
+++ b/workflows/mark02.smk
@@ -56,7 +56,7 @@ CS_seed = 42 # <-- configure cell simulation seed here
 #####################
 # True Tree Parameters
 tree_types = ["r"] # <-- configure tree type here ["r","s","d"]
-tree_seeds = [42, 34] # <-- configure tree seed here
+tree_seeds = [42]#, 34] # <-- configure tree seed here
 
 #####################
 #####################
@@ -66,8 +66,8 @@ tree_seeds = [42, 34] # <-- configure tree seed here
 # given each error rate, true tree, no of cells and mutations
 initial_points = [ # (mcmc_seed, init_tree_type, init_tree_seed)
     (42, 'r', 45),
-    (12, 'r', 34),
-    (34, 'r', 42),
+    (12, 'r', 20),
+    (34, 'r', 31),
     (79, 'r', 89),
 ]
 

--- a/workflows/mark03.smk
+++ b/workflows/mark03.smk
@@ -452,3 +452,39 @@ rule combined_logProb_iteration_plot:
 
         # save the histogram
         fig.savefig(Path(output.combined_logP_iter))
+
+
+rule get_log_probs_2:
+    """Extract log probabilities from MCMC samples for ease of plotting / analysis.
+        Saves into true tree directory. - not nessary but good for workflow design
+
+        Note this rule is needed only for the MARK03 experiment due to diffuculties with
+        wildcards in the output path.
+        """
+    input:
+        mcmc_samples="{DATADIR}/{experiment}/mcmc/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}.json",
+    wildcard_constraints:
+        mcmc_config_id="MC_(?:(?!/).)+",
+        init_tree_id="(HUN|T)_(?:(?!/).)+"
+
+    output:
+        result="{DATADIR}/{experiment}/analysis/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}/T_{base_tree_type}_{n_nodes,\d+}_{base_tree_seed,\d+}/log_prob.json",
+    run:
+        # load the data
+        mcmc_samples = yg.serialize.read_mcmc_samples(Path(input.mcmc_samples))
+        mcmc_data = yg.analyze.to_pure_mcmc_data(mcmc_samples)
+
+        # write the result
+        fp = Path(output.result)
+
+        # get log probs
+        log_probs = mcmc_data.log_probabilities
+        # convert log probs to list of float
+        log_probs = [float(i) for i in log_probs]
+        # get iteration
+        iteration = mcmc_data.iterations
+        # convert iterations of list of int
+        iteration = [int(i) for i in iteration]
+
+        # save
+        yg.serialize.save_metric_result(iteration,log_probs,fp)

--- a/workflows/mark03.smk
+++ b/workflows/mark03.smk
@@ -16,8 +16,8 @@ from pyggdrasil.tree_inference import CellSimulationId, TreeType, TreeId, McmcCo
 
 #####################
 # Environment variables
-DATADIR = "../data"
-# DATADIR = "/cluster/work/bewi/members/gkoehn/data"
+#DATADIR = "../data"
+DATADIR = "/cluster/work/bewi/members/gkoehn/data"
 
 #####################
 experiment = "mark03"

--- a/workflows/mark_viz.smk
+++ b/workflows/mark_viz.smk
@@ -18,4 +18,6 @@ rule mark_viz:
     input:
         f"{DATADIR}/{experiment}/plots/T_r_10_42_relabeled.svg",
         f"{DATADIR}/{experiment}/plots/T_d_10_42_relabeled.svg",
-        f"{DATADIR}/{experiment}/plots/T_s_10_relabeled.svg"
+        f"{DATADIR}/{experiment}/plots/T_s_10_relabeled.svg",
+        f"{DATADIR}/{experiment}/plots/T_r_6_42_relabeled.svg",
+        f"{DATADIR}/{experiment}/plots/T_r_51_42_relabeled.svg",

--- a/workflows/mark_viz.smk
+++ b/workflows/mark_viz.smk
@@ -21,3 +21,10 @@ rule mark_viz:
         f"{DATADIR}/{experiment}/plots/T_s_10_relabeled.svg",
         f"{DATADIR}/{experiment}/plots/T_r_6_42_relabeled.svg",
         f"{DATADIR}/{experiment}/plots/T_r_51_42_relabeled.svg",
+        f"{DATADIR}/{experiment}/plots/T_r_6_45_relabeled.svg",
+        f"{DATADIR}/{experiment}/plots/T_r_6_20_relabeled.svg",
+        f"{DATADIR}/{experiment}/plots/T_r_6_34_relabeled.svg",
+        f"{DATADIR}/{experiment}/plots/T_r_6_89_relabeled.svg",
+
+
+

--- a/workflows/tree_inference.smk
+++ b/workflows/tree_inference.smk
@@ -18,8 +18,8 @@ from pyggdrasil.tree_inference import (
 ###############################################
 ## Relative path from DATADIR to the repo root
 
-#REPODIR = "/cluster/work/bewi/members/gkoehn/repos/PYggdrasil"
-REPODIR = ".."
+REPODIR = "/cluster/work/bewi/members/gkoehn/repos/PYggdrasil"
+#REPODIR = ".."
 #DATADIR = "/cluster/work/bewi/members/gkoehn/data"
 
 ###############################################

--- a/workflows/tree_inference.smk
+++ b/workflows/tree_inference.smk
@@ -18,8 +18,8 @@ from pyggdrasil.tree_inference import (
 ###############################################
 ## Relative path from DATADIR to the repo root
 
-REPODIR = "/cluster/work/bewi/members/gkoehn/repos/PYggdrasil"
-#REPODIR = ".."
+#REPODIR = "/cluster/work/bewi/members/gkoehn/repos/PYggdrasil"
+REPODIR = ".."
 #DATADIR = "/cluster/work/bewi/members/gkoehn/data"
 
 ###############################################

--- a/workflows/visualize.smk
+++ b/workflows/visualize.smk
@@ -102,7 +102,7 @@ rule plot_tree:
     input:
         tree="{DATADIR}/{experiment}/trees/{tree_id}.json",
     wildcard_constraints:
-        tree_id = "(HUN|T)_(?:(?!/).)+" # allowing both generated and huntress trees
+        tree_id = "^(?!.*_relabeled)(HUN|T)_(?:(?!/).)+$" # allowing both generated and huntress trees
     output:
         plot="{DATADIR}/{experiment}/plots/{tree_id}.svg",
     run:

--- a/workflows/visualize.smk
+++ b/workflows/visualize.smk
@@ -101,6 +101,8 @@ rule plot_tree:
     """Plot a raw tree"""
     input:
         tree="{DATADIR}/{experiment}/trees/{tree_id}.json",
+    wildcard_constraints:
+        tree_id = "(HUN|T)_(?:(?!/).)+" # allowing both generated and huntress trees
     output:
         plot="{DATADIR}/{experiment}/plots/{tree_id}.svg",
     run:


### PR DESCRIPTION
the log_prob plots were missing inputs. 

Needed to add another dirty rule to make this work.

This PR also implements some fixed for MARK02. 
The initial trees for MAKR02 were the true trees twice.