### PR TITLE
Adding more Tree Similarity Measures

### DIFF
--- a/src/pyggdrasil/analyze/_metrics.py
+++ b/src/pyggdrasil/analyze/_metrics.py
@@ -3,7 +3,7 @@
 from typing import Callable, Dict
 
 from pyggdrasil import TreeNode, compare_trees
-from pyggdrasil.distances import MP3Similarity, AncestorDescendantSimilarity
+import pyggdrasil.distances as dist
 
 
 class Metrics:
@@ -15,7 +15,9 @@ class Metrics:
         return Metrics._METRICS[metric]
 
     _METRICS: Dict[str, Callable[[TreeNode, TreeNode], float]] = {  # type: ignore
-        "AD": AncestorDescendantSimilarity().calculate,
-        "MP3": MP3Similarity().calculate,
+        "AD": dist.AncestorDescendantSimilarity().calculate,
+        "MP3": dist.MP3Similarity().calculate,
         "TrueTree": compare_trees,
+        "DL": dist.DifferentLineageSimilarity().calculate,
+        "MLTD": dist.MLTDSimilarity().calculate,
     }

--- a/src/pyggdrasil/distances/__init__.py
+++ b/src/pyggdrasil/distances/__init__.py
@@ -9,6 +9,8 @@ from pyggdrasil.distances._utils import calculate_distance_matrix
 from pyggdrasil.distances._scphylo_wrapper import (
     AncestorDescendantSimilarity,
     MP3Similarity,
+    DifferentLineageSimilarity,
+    MLTDSimilarity,
 )
 
 from pyggdrasil.distances._similarities import AncestorDescendantSimilarityInclRoot
@@ -22,4 +24,6 @@ __all__ = [
     "AncestorDescendantSimilarity",
     "MP3Similarity",
     "AncestorDescendantSimilarityInclRoot",
+    "DifferentLineageSimilarity",
+    "MLTDSimilarity",
 ]

--- a/src/pyggdrasil/distances/_scphylo_wrapper.py
+++ b/src/pyggdrasil/distances/_scphylo_wrapper.py
@@ -96,3 +96,70 @@ class MP3Similarity(interface.TreeSimilarity):
             ``False`` should be returned.
         """
         return True
+
+
+class DifferentLineageSimilarity(interface.TreeSimilarity):
+    """Different-Lineage similarity.
+
+    Similarity out of one."""
+
+    def calculate(self, /, tree1: anytree.Node, tree2: anytree.Node) -> float:
+        """Calculates similarity between ``tree1`` and ``tree2`` using `scphulo.tl.dl`.
+
+        Args:
+            tree1: root of the first tree. The nodes should be labeled with integers.
+            tree2: root of the second tree. The nodes should be labeled with integers.
+
+        Returns:
+            similarity from ``tree1`` to ``tree2``
+        """
+        df1 = utils.tree_to_dataframe(tree1)
+        df2 = utils.tree_to_dataframe(tree2)
+        return scphylo.tl.dl(df1, df2)
+
+    def is_symmetric(self) -> bool:
+        """Returns ``True`` if the similarity function is symmetric,
+        i.e., :math:`s(t_1, t_2) = s(t_2, t_1)` for all pairs of trees.
+
+        Note:
+            If it is not known whether the similarity function is symmetric,
+            ``False`` should be returned.
+
+        Unknown, but probably not symmetric.
+        """
+        return False
+
+
+class MLTDSimilarity(interface.TreeSimilarity):
+    """Multi-labeled tree dissimilarity measure (MLTD), normalized to [0,1].
+
+    Similarity out of one.
+
+    Raises: Segmentation faults sometimes, unknown why. - scyphylo's issue.
+    """
+
+    def calculate(self, /, tree1: anytree.Node, tree2: anytree.Node) -> float:
+        """Calculates similarity between ``tree1`` and ``tree2`` using `scphulo.tl.dl`.
+
+        Args:
+            tree1: root of the first tree. The nodes should be labeled with integers.
+            tree2: root of the second tree. The nodes should be labeled with integers.
+
+        Returns:
+            similarity from ``tree1`` to ``tree2``
+        """
+        df1 = utils.tree_to_dataframe(tree1)
+        df2 = utils.tree_to_dataframe(tree2)
+        return scphylo.tl.mltd(df1, df2)["normalized_similarity"]
+
+    def is_symmetric(self) -> bool:
+        """Returns ``True`` if the similarity function is symmetric,
+        i.e., :math:`s(t_1, t_2) = s(t_2, t_1)` for all pairs of trees.
+
+        Note:
+            If it is not known whether the similarity function is symmetric,
+            ``False`` should be returned.
+
+        Unknown, but probably not symmetric.
+        """
+        return False

--- a/tests/distances/test_scphylo_wrapper.py
+++ b/tests/distances/test_scphylo_wrapper.py
@@ -31,7 +31,12 @@ def model_tree() -> anytree.Node:
 
 
 @pytest.mark.parametrize(
-    "similarity", [dist.MP3Similarity(), dist.AncestorDescendantSimilarity()]
+    "similarity",
+    [
+        dist.MP3Similarity(),
+        dist.AncestorDescendantSimilarity(),
+        dist.DifferentLineageSimilarity(),
+    ],
 )
 def test_self_similarity(similarity, model_tree) -> None:
     """Tests whether similarity(tree, tree) = 1."""
@@ -50,7 +55,13 @@ def test_self_similarity(similarity, model_tree) -> None:
 
 
 @pytest.mark.parametrize(
-    "similarity", [dist.MP3Similarity(), dist.AncestorDescendantSimilarity()]
+    "similarity",
+    [
+        dist.MP3Similarity(),
+        dist.AncestorDescendantSimilarity(),
+        dist.DifferentLineageSimilarity(),
+        dist.MLTDSimilarity(),
+    ],
 )
 def test_another_is_different_and_symmetric(similarity, model_tree) -> None:
     """Test whether the similarity of different trees is less than 1.0.
@@ -180,6 +191,67 @@ def test_AncestorDescendantSimilarity_lq(
         )
         print("\n")
         print(f"AD_lq: {result2}")
+    except Exception as e:
+        print("\n")
+        tree1.print_topo()
+        tree2.print_topo()
+        raise e
+
+
+@pytest.mark.parametrize("tree_type1", ["r"])
+@pytest.mark.parametrize("seed1", [76, 42])
+@pytest.mark.parametrize("tree_type2", ["r"])
+@pytest.mark.parametrize("seed2", [13, 42])
+@pytest.mark.parametrize("n_nodes", [5, 10])
+def test_DifferentLineagesSimilarity(
+    n_nodes: int, tree_type1, seed1: int, tree_type2, seed2: int
+):
+    """"""
+
+    tree1_fn = tree_gen(tree_type=tree_type1, seed=seed1)
+    tree2_fn = tree_gen(tree_type=tree_type2, seed=seed2)
+
+    tree1 = tree1_fn(n_nodes)
+    tree2 = tree2_fn(n_nodes)
+    sim2 = dist.DifferentLineageSimilarity()
+
+    try:
+        result2 = sim2.calculate(
+            TreeNode.convert_to_anytree_node(tree1),
+            TreeNode.convert_to_anytree_node(tree2),
+        )
+        print("\n")
+        print(f"MLTD normalized: {result2}")
+    except Exception as e:
+        print("\n")
+        tree1.print_topo()
+        tree2.print_topo()
+        raise e
+
+
+@pytest.mark.skip("Raises Segmentation fault for some trees")
+@pytest.mark.parametrize("tree_type1", ["r"])
+@pytest.mark.parametrize("seed1", [76, 42])
+@pytest.mark.parametrize("tree_type2", ["r"])
+@pytest.mark.parametrize("seed2", [13, 42])
+@pytest.mark.parametrize("n_nodes", [5, 10])
+def test_MLTDSimilarity(n_nodes: int, tree_type1, seed1: int, tree_type2, seed2: int):
+    """"""
+
+    tree1_fn = tree_gen(tree_type=tree_type1, seed=seed1)
+    tree2_fn = tree_gen(tree_type=tree_type2, seed=seed2)
+
+    tree1 = tree1_fn(n_nodes)
+    tree2 = tree2_fn(n_nodes)
+    sim2 = dist.MLTDSimilarity()
+
+    try:
+        result2 = sim2.calculate(
+            TreeNode.convert_to_anytree_node(tree1),
+            TreeNode.convert_to_anytree_node(tree2),
+        )
+        print("\n")
+        print(f"MLTD normalized: {result2}")
     except Exception as e:
         print("\n")
         tree1.print_topo()

--- a/workflows/mark01.smk
+++ b/workflows/mark01.smk
@@ -18,7 +18,7 @@ DATADIR = "/cluster/work/bewi/members/gkoehn/data"
 experiment="mark01"
 
 # Metrics: Distances / Similarity Measure to use
-metrics = ["MP3","AD"]  # also AD <-- configure distances here
+metrics = ["MP3","AD","DL"]  # <-- configure distances here
 
 #####################
 # Cell Simulation Parameters

--- a/workflows/mark02.smk
+++ b/workflows/mark02.smk
@@ -23,7 +23,7 @@ DATADIR = "/cluster/work/bewi/members/gkoehn/data"
 experiment="mark02"
 
 # Metrics: Distances / Similarity Measure to use
-metrics = ["MP3", "AD"]  # also AD <-- configure distances here
+metrics = ["MP3", "AD", "DL"]  # also AD <-- configure distances here
 
 #####################
 # Error Parameters

--- a/workflows/mark02.smk
+++ b/workflows/mark02.smk
@@ -237,7 +237,7 @@ rule combined_chain_histogram:
             ax.hist(sublist,bins='auto',alpha=0.5,color=colors[color_index],label=labels[i])
 
         # Set labels and title
-        ax.set_xlabel(f"Distance/Similarity: {wildcards.metric}")
+        ax.set_xlabel(f"Similarity: {wildcards.metric}")
         ax.set_ylabel('Frequency')
 
         # Add a legend

--- a/workflows/mark03.smk
+++ b/workflows/mark03.smk
@@ -26,7 +26,7 @@ DATADIR = "/cluster/work/bewi/members/gkoehn/data"
 experiment = "mark03"
 
 # Metrics: Distances / Similarity Measure to use
-metrics = ["MP3", "AD", "log_prob"]  # <-- configure distances here
+metrics = ["MP3", "AD", "log_prob", "DL"]  # <-- configure distances here
 
 #####################
 # Error Parameters

--- a/workflows/mark03.smk
+++ b/workflows/mark03.smk
@@ -397,7 +397,7 @@ def plot_iteration_metric(all_chain_metrics : list[str], metric : str, output_pa
         )
 
     # Set labels and title
-    ax.set_ylabel(f"Distance/Similarity: {metric}")
+    ax.set_ylabel(f"Similarity: {metric}")
     ax.set_xlabel("Iteration")
 
     # Add a legend of fixed legend position and size


### PR DESCRIPTION
As discussed yesterday, it may strengthen our argument in the initial experiments if we have more tree similarity measures to show for.

Here I implement the 
- Different-Lineage (DL)
- Multi-labeled tree dissimilarity measure (MLTD)

from `scphylo`

DL works fine. MLTD, unfortunately, returns `Fatal Python Error: Segmentation Fault` sometimes. 

I left both there, yet suggest only to use DL, added a note the MLTD. 

Will make all plots with the DL then.