### PR TITLE
Update ReadMe and About

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # PYggdrasil
 
-Python package for inference and analysis of mutation trees and copy number trees.
+Python package for inference and analysis of mutation trees.
 
 
 ## Usage


### PR DESCRIPTION
Minor update to the package description. 

I removed the reference to copy number trees - as noted by Niko. 

To make this coherent we also need to edit the "About" section of this repository: 
- [x] @pawel-czyz, could you please make this change to the "About" - I don't have the permissions here.

