### PR TITLE
Consider Blocking HUNTRESS Easy Data 

### DIFF
--- a/src/pyggdrasil/tree_inference/__init__.py
+++ b/src/pyggdrasil/tree_inference/__init__.py
@@ -41,6 +41,7 @@ from pyggdrasil.tree_inference._simulate import (
     CellSimulationModel,
     get_simulation_data,
     CellSimulationData,
+    scramble_node_order_mutations
 )
 
 from pyggdrasil.tree_inference._file_id import (
@@ -100,4 +101,5 @@ __all__ = [
     "ErrorCombinations",
     "evolve_tree_mcmc",
     "make_tree",
+    "scramble_node_order_mutations"
 ]

--- a/src/pyggdrasil/tree_inference/_simulate.py
+++ b/src/pyggdrasil/tree_inference/_simulate.py
@@ -732,3 +732,31 @@ def get_simulation_data(data: dict) -> CellSimulationData:
         noisy_mutation_mat=noisy_mutation_mat,
         root=root,
     )
+
+
+def scramble_node_order_mutations(
+    mutation_data: MutationMatrix, rng: JAXRandomKey
+) -> MutationMatrix:
+    """Scramble the order of the nodes in the mutation matrix.
+
+      This may be useful to block technical artefacts.
+      i.e. HUNTRESS may perform better on an ordered mutation matrix.
+
+    Args:
+        mutation_data: MutationMatrix
+            Mutation matrix to scramble.
+        rng: JAX random number generator.
+
+    Returns:
+        Scrambled mutation matrix.
+    """
+    # get shape of mutation matrix
+    n_mutations, n_cells = mutation_data.shape
+
+    # get random permutation of nodes
+    permutation = random.permutation(rng, n_mutations)
+
+    # apply permutation to mutation matrix
+    mutation_data_scrambled = mutation_data[permutation, :]
+
+    return mutation_data_scrambled

--- a/workflows/tree_inference.smk
+++ b/workflows/tree_inference.smk
@@ -223,6 +223,10 @@ rule run_huntress:
         data_fn = Path(input.mutation_data).stem
         # try to match the cell simulation id
         cell_sim_id = yg.tree_inference.CellSimulationId.from_str(data_fn)
+        # scramble the mutation matrix, to avoid technical artifacts
+        # i.e. HUNTRESS may perform better if the mutation matrix is sorted
+        rng = jax.random.PRNGKey(cell_sim_id.seed)
+        mut_mat_scrambled = yg.tree_inference.scramble_node_order_mutations(mut_mat,rng)
         # run huntress
         huntress_tree = yg.tree_inference.huntress_tree_inference(mut_mat,cell_sim_id.fpr,cell_sim_id.fnr, n_threads=threads)
         # make TreeNode from Node


### PR DESCRIPTION
**ON HOLD - NOT TO BE MERGED**

I recall Jack asked if we scramble the order of mutation matrices before we feed them to HUNTRESS. His doubt was that perhaps the order of tree labels and the mutation matrix is somewhat beneficial to the inference performed by HUNTRESS. 

To block this technical artefact we could reorder the mutation matrix rows.

We currently don't. In this PR I considered this quickly. 

The issue is that HUNTRESS does take the mutation matrix indices as the node names. Thus one would have to relabel the nodes again after Huntress is performed. 

This brings a few ways to introduce errors I suppose. 

It is probably best to wait and see if the advantage of HUNTRESS is still so pronounced now that SCITE should be fixed soon.


