### PR TITLE
Fixing DATADIR in MARK02 long runs

### DIFF
--- a/workflows/analyze.smk
+++ b/workflows/analyze.smk
@@ -7,6 +7,11 @@ import pyggdrasil as yg
 from pathlib import Path
 
 
+def get_mem_mb(wildcards, attempt):
+    """Get adaptive memory in MB for a given rule."""
+    return attempt * 2000
+
+
 rule analyze_metric:
     """Analyze MCMC run with a metric taking a base tree and
      an MCMC sample as input i.e. all distances /similarity metrics.
@@ -18,6 +23,8 @@ rule analyze_metric:
         mcmc_config_id = "MC.*",
         # metric wildcard cannot be log_prob
         metric=r"(?!(log_prob))\w+",
+    resources:
+        mem_mb=get_mem_mb,
     output:
         result="{DATADIR}/{experiment}/analysis/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}/{base_tree_id}/{metric}.json",
         log="{DATADIR}/{experiment}/analysis/MCMC_{mcmc_seed,\d+}-{mutation_data_id}-i{init_tree_id}-{mcmc_config_id}/{base_tree_id}/{metric}.log",

--- a/workflows/mark02.smk
+++ b/workflows/mark02.smk
@@ -323,15 +323,15 @@ rule mark02_long:
         ### 50 mutations - 200 cells
         ## typical noise (1e-06, 0.1)
         # histograms
-        "../data/mark02/plots/MC_1e-06_0.1_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_1e-06_0.1_0.0_f_UXR/T_r_51_42/AD.svg",
-        "../data/mark02/plots/MC_1e-06_0.1_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_1e-06_0.1_0.0_f_UXR/T_r_51_42/DL.svg",
+        f"{DATADIR}/mark02/plots/MC_1e-06_0.1_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_1e-06_0.1_0.0_f_UXR/T_r_51_42/AD.svg",
+        f"{DATADIR}/mark02/plots/MC_1e-06_0.1_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_1e-06_0.1_0.0_f_UXR/T_r_51_42/DL.svg",
         # AD_DL Rhat
-        "/data/mark02/plots/MC_1e-06_0.1_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_1e-06_0.1_0.0_f_UXR/T_r_51_42/AD_DL/rhat4-MCMCseeds_s42_s12_s34_s79-iTrees_iT_r_31_45_iT_r_31_20_iT_r_31_31_iT_r_31_89/rhat.svg",
+        f"{DATADIR}/mark02/plots/MC_1e-06_0.1_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_1e-06_0.1_0.0_f_UXR/T_r_51_42/AD_DL/rhat4-MCMCseeds_s42_s12_s34_s79-iTrees_iT_r_31_45_iT_r_31_20_iT_r_31_31_iT_r_31_89/rhat.svg",
         # large noise (0.01, 0.2)
         # histograms
-        "../data/mark02/plots/MC_0.01_0.2_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_0.01_0.2_0.0_f_UXR/T_r_51_42/AD.svg",
-        "../data/mark02/plots/MC_0.01_0.2_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_0.01_0.2_0.0_f_UXR/T_r_51_42/DL.svg",
+        f"{DATADIR}/mark02/plots/MC_0.01_0.2_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_0.01_0.2_0.0_f_UXR/T_r_51_42/AD.svg",
+        f"{DATADIR}/mark02/plots/MC_0.01_0.2_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_0.01_0.2_0.0_f_UXR/T_r_51_42/DL.svg",
         # AD_DL Rhat
-        "../data/mark02/plots/MC_0.01_0.2_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_0.01_0.2_0.0_f_UXR/T_r_51_42/AD_DL/rhat4-MCMCseeds_s42_s12_s34_s79-iTrees_iT_r_31_45_iT_r_31_20_iT_r_31_31_iT_r_31_89/rhat.svg"
+        f"{DATADIR}/mark02/plots/MC_0.01_0.2_100000_0_1-MPC_0.1_0.65_0.25/CS_42-T_r_51_42-200_0.01_0.2_0.0_f_UXR/T_r_51_42/AD_DL/rhat4-MCMCseeds_s42_s12_s34_s79-iTrees_iT_r_31_45_iT_r_31_20_iT_r_31_31_iT_r_31_89/rhat.svg"
 
 


### PR DESCRIPTION
The datadir path was hardcoded for the mark02 long runs.