### PR TITLE
Fixing Paths for Figures in mkdocs/quarto

### DIFF
--- a/docs/tutorial/singleMCMC.md
+++ b/docs/tutorial/singleMCMC.md
@@ -166,7 +166,7 @@ plt.grid()
 plt.show()
 ```
 
-<img src="singleMCMC_files/figure-commonmark/log-prob-iter-output-1.png"
+<img src="../singleMCMC_files/figure-commonmark/log-prob-iter-output-1.png"
 id="log-prob-iter"
 alt="The evolution of the log-probability of the trees over the MCMC iterations." />
 


### PR DESCRIPTION
The combination of `mkdocs` and `quarto' results in some minor issues. 

The filepath of figures misses a `../` as mkdocs makes a directory with an index.md instead of a file. 

This changes the relative path required wrt to one built by quarto.

In this PR I am trialing if the path manually adjusted in the markdown generated by quarto persists.